### PR TITLE
Add GitLab to remote companies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@ A curated list of awesome remote jobs
   1. [Mozilla](https://careers.mozilla.org/en-US/listings/)
   1. [Wikimedia](http://wikimediafoundation.org/wiki/Work_with_us)
   1. [DataStax](http://www.datastax.com/company/careers)
+  1. [GitLab](https://about.gitlab.com/jobs/) 


### PR DESCRIPTION
GitLab is a fully remote company and almost everyone works exclusively remote, minus a tiny Ukrainian office for two of our awesome developers.

Read more about it here: https://about.gitlab.com/2014/07/03/how-gitlab-works-remotely/