### PR TITLE
give a > small some breathing room

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -43,6 +43,7 @@ a small {
   color:#777;
   margin-top:-0.6em;
   display:block;
+  line-height:2em;
 }
 
 .wrapper {


### PR DESCRIPTION
otherwise it's too close to the non-small content of the link