### PR TITLE
Remove trailing slash in the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ A curated list of awesome [remote working](http://en.wikipedia.org/wiki/Telecomm
   1. [Modern Tribe](http://tri.be/about/join-our-team/) - A digital agency with a modern twist. All freelancers. All experts.
   1. [Mozilla](https://careers.mozilla.org/en-US/listings/)
   1. [Next Big Sound](https://jobs.lever.co/nextbigsound/) - Analytics and Insights for the Music Industry.
-  1. [NodeSource](https://nodesource.com/company/) - NodeSource is dedicated to creating a sustainable ecosystem for Node.js.
+  1. [NodeSource](https://nodesource.com/company) - NodeSource is dedicated to creating a sustainable ecosystem for Node.js.
   1. [Railsdog](http://railsdog.com/) - eCommerce solutions and integrations based on Spree (Ruby on Rails). Most team members are distributed including development, project management, and executive roles.
   1. [RebelMouse](https://blog.rebelmouse.com/jobs/) - Social publishing platform. Python, JS & iOS/Android developers. All over the world team.
   1. [Red Hat](http://jobs.redhat.com/)


### PR DESCRIPTION
Apparently trailing slash is not needed as it results in 404.
Btw their 404 page is awesome: https://nodesource.com/404!