### PR TITLE
Remove dead link to remotehackers.com job board

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ A curated list of awesome [remote working](http://en.wikipedia.org/wiki/Telecomm
   1. [No Fluff Jobs](https://nofluffjobs.com/#criteria=remote) filter -> "*remote*"
   1. [Nomad Jobs](http://nomadjobs.io/)
   1. [Remote Coder](http://remotecoder.io)
-  1. [Remote Hackers](http://remotehackers.com/)
   2. [Remote OK](http://remoteok.io/) - scrapes many job board feeds for remote positions
   1. [RemoteWorkHunt] (http://www.remoteworkhunt.com/)
   1. [Remotive Jobs](http://jobs.remotive.io/)


### PR DESCRIPTION
The [remotehackers.com](remotehackers.com) job board link doesn't seem to lead to anything any more: 

![image](https://cloud.githubusercontent.com/assets/296432/7380625/dc5403c6-edf4-11e4-8406-421811fb18b4.jpg)

This PR removes it from the list. 💇🏼