### PR TITLE
Update URL to Healthfinch's careers page

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ A curated list of awesome [remote working](http://en.wikipedia.org/wiki/Telecomm
   1. [GitHub](https://github.com/about/jobs)
   1. [GitLab](https://about.gitlab.com/jobs/) - Competitor to GitHub.
   1. [Harvest](https://www.getharvest.com/careers) - Time tracking software.
-  1. [Healthfinch](http://www.healthfinch.com/jobs) - Making Healthcare systems more usable. HQ in Madison, WI, USA. Ruby, Javascript.
+  1. [Healthfinch](http://www.healthfinch.com/careers) - Making Healthcare systems more usable. HQ in Madison, WI, USA. Ruby, Javascript.
   1. [Heap](https://heapanalytics.com/jobs) – Web & Mobile Analytics, 2 of our 8 teammates are remote.
   1. [Heroku](http://jobs.heroku.com/) - PaaS Cloud, makes devs' experience awesome, Ruby, Erlang, Javascript, Golang, Python.
   1. [Honeybadger](https://www.honeybadger.io/) - Ruby. 100% remote.


### PR DESCRIPTION
While perusing the list this morning, got a 404 for [Healthfinch](http://www.healthfinch.com). Here's to saving everyone else the trouble of resolving it manually.