### PR TITLE
Fix jobs link and extended description for Auth0

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 ## Companies with "remote DNA"
   1. [Arkency](https://blog.arkency.com) - Rails and React.js experts, fully remote/async
   1. [Articulate](https://www.articulate.com/company/careers.php) - EdTech. Makes software that helps teachers make e-learning courses. Ruby, Node, C#, and .NET for Windows app.
-  1. [Auth0](https://auth0.com/) - Identity for developers
+  1. [Auth0](https://auth0.com/jobs) - Zero-friction authentication and authorization for developers.
   1. [Automattic](https://automattic.com/work-with-us/) - Makers of WordPress.com and Gravatar
   1. [Avallain](http://www.avallain.com/) - Education Technology and Digital Publishing. We have the tools and processes to achieve the positive impact on human potential that technology enhanced education can provide
   1. [BaseCamp](https://basecamp.com/team) - Project management software


### PR DESCRIPTION
Previous https://auth0.com links to the main page.
