### PR TITLE
Fix hiring link and expand trivia for Close.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Chef](https://www.chef.io/careers/) - We are all about IT automation for speed and awesomeness. Ruby, JavaScript & shell scripting. HQ in Seattle but we have employees all around US.
   1. [CircleCI](https://circleci.com/jobs#engineer) - Provides continuous integration tools and services.
   1. [Clevertech](https://clevertech.biz/) - We build incredible, game changing technology.
-  2. [Close.io](http://close.io/) - CRM (python)
+  2. [Close.io](http://jobs.close.io) - Inside sales CRM for startups and SMBs.
   1. [Codeship](https://codeship.com/jobs) - SaaS Continuous Delivery
   1. [Collabora](https://www.collabora.com/about-us/careers.html) - Open source software-based consulting.
   1. [Compose](https://www.compose.io/jobs/) - Managing databases as a service. Distributed team with offices in San Meteo, CA and Birmingham, AL.


### PR DESCRIPTION
Previous http://close.io links just to the main page.