### PR TITLE
Add Timing (automatic time tracking for Mac)

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Noisli](https://www.noisli.com/) - Noisli has a list of diferent ambient sounds that can be combined to boost creativity and focus.
   1. [Qbserve](https://qotoqot.com/qbserve/) - Time tracking automation: freelance project tracking, timesheets, invoicing & real-time productivity feedback (Mac).
   1. [Teleport Sundial](https://sundial.teleport.org) - Manage the locations and timezones of your distributed team.
+  1. [Timing](https://timingapp.com/) - Automatic time and productivity tracking for Mac. Helps you stay on track with your work (especially important when working remotely). Also ensures that no billable hours get lost if you are billing hourly (Mac).
 
 ## Law & Finance
   1. [1099 contractors](http://www.wisegeek.com/what-is-a-1099-contractor.htm) – US based companies can hire remote workers as.


### PR DESCRIPTION
This commit adds another time tracking app to the list. For testimonials of its awesomeness, see [our Product Hunt page](https://www.producthunt.com/posts/timing-2-3) and [the old version's Mac App Store page](https://itunes.apple.com/us/app/id431511738?mt=12&ign-mpt=uo%3D4). Also happy to send you a free copy so you can see for yourself :-)