### PR TITLE
Updated Home Work podcast to state archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 
 ## Podcasts
   1. [Free People Move Podcast](https://teleport.org/podcast/) - mostly interviews with founders attacking the location independence / remote work space from different angles
-  1. [Home Work](http://5by5.tv/homework) - A weekly advice podcast for people who work from home.
+  1. [Home Work](http://5by5.tv/homework) - A weekly advice podcast for people who work from home. (No longer in production but archive still available)
   1. [Lessons from Distributed Companies](https://www.lullabot.com/podcasts/drupalizeme-podcast/lessons-from-distributed-companies)
   1. [Remote Works](https://remote.works) - The Remote Works podcast publishes every two weeks with host Jonathan Sharp discussing the opportunities, experiences, culture and community surrounding remote work, remote teams, telecommuting and digital nomads.
   1. [The Yonder Podcast](https://www.yonder.io/post?category=Podcast) - Bi-weekly podcast: Jeff Robbins interviews people thinking about distributed teams, remote work, and how to support happy, productive, free-range workers.


### PR DESCRIPTION
5by5 have now retired the Home Work podcast. The archives still exist but there will be no future episodes so I have updated the description to reflect this.