### PR TITLE
Remove design, inc. (no longer in operation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 - [Books](#books)
 - [Comics](#comics)
 - [Job boards](#job-boards)
-- [Freelance marketplaces](#freelance-marketplaces)
 - [Housing](#housing)
 - [Interviewing](#interviewing)
 - [Events](#events)
@@ -157,9 +156,6 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Working Nomads](http://www.workingnomads.co/jobs)
   1. [Workana](https://www.workana.com/) Freelance Job Board in Spanish and Portuguese
   1. [Work Remotely](https://workremotely.io/) - Crawls and curates many job board feeds for remote positions
-
-## Freelance marketplaces
-  1. [Design Inc.](https://www.designinc.com)
 
 ## Housing
   1. [bedndesk](http://www.bedndesk.com) - Coworking & coliving space in Mallorca island in Spain


### PR DESCRIPTION
Removed the "freelance marketplace" section since this was the only listing and I couldn't think of other quality ones to add.