### PR TITLE
WFH.io redirects to weworkremotely.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Vue.js Jobs](https://vuejobs.com/) Find Vue.js jobs all around the world - Click on "Remote" tab.
   1. [React.js Jobs](https://www.react-jobs.com) Find React.js jobs all around the world - Click on "Remote" toggle button.
   1. [We Work Remotely](https://weworkremotely.com/)
-  1. [WFH.io](https://www.wfh.io/)
   1. [Workana](https://www.workana.com/) Freelance Job Board in Spanish and Portuguese
   1. [Working Nomads](http://www.workingnomads.co/jobs)
 


### PR DESCRIPTION
We Work Remotely acquired them back in April of this year