### PR TITLE
Added JustRemote to list of Job Boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [JOBBOX.io](https://landing.jobs/offers) – Filter -> Remote only.
   1. [Jobhunt.ai](https://jobhunt.ai/machinelearning-remote-jobs.html) – Machine learning jobs. Filter -> Remote only.
   1. [Jobspresso](https://jobspresso.co/) * High-quality remote positions that are open and legitimate *
+  1. [JustRemote](https://justremote.co/) – Global remote positions that are fully or partially Remote
   1. [Landing.jobs](https://landing.jobs/offers) filter -> Remote only
   1. [Larajobs](https://larajobs.com/?location=&remote=1) – The artisan employment connection
   1. [No Fluff Jobs](https://nofluffjobs.com/#criteria=remote) – Filter -> “*remote*”


### PR DESCRIPTION
Hi @lukasz-madon 

I hope you don't mind but I would really love to add JustRemote.co to your list of Job Boards. We've recently launched and are specifically trying to list both partial and fully remote roles to give people more options. 

I have added JustRemote in and maintained the alphabetical order of things. 

If you require anything else then please do let me know. 

Cheers,
Tom