### PR TITLE
Add a PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+<!-- Thanks for adding a resource about remote work to this list! 🎉
+
+Please fill in the below placeholders -->
+
+**[Insert URL you're adding here]**
+
+**[Explain what this URL adds and why it is awesome]**
+
+<!-- Make sure your pull request follows the [Contribution Guidelines](CONTRIBUTING.md) before submitting! Thank you. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ If you're making a pull request, please ensure it adheres to the following guide
 
 1. Check if the link is working and pointing to the right location.
 2. Check your spelling and grammar.
-3. Choose the correct corresponding section.
+3. Choose the appropriate corresponding section.
 4. The list, after your addition, should be sorted alphabetically.
 5. Make an individual pull request for each suggestion.
 6. If you use a text editor to fashion the pull request, make sure your text editor is set to remove trailing whitespace.
@@ -20,7 +20,7 @@ If you're making a pull request, please ensure it adheres to the following guide
     1. [Foo](foo.io) - We are building new certificate provider based on crypocurrencies. Python, Scala, JS, Full Time
     2. [Bar](bar.io) - Uber for fruit baskets. Node, grunt, JS, workday overlaps New York afternoons (1700 - 2200 UTC)
 13. Any new entry should have meaningful content at the time of the addition to this list. We can't tell whether something is awesome if there is little to see. As a general rule, there should be at least about six months worth of content.
-14. Companies, if added, should have "remote DNA". This means they are not only remote friendly, but dedicated to remote work as a core of their business.
+14. Companies in this list should have "remote DNA". This means they are not only remote friendly, but dedicated to remote work as a core of their business.
 15. Link to the career/job page rather than to a single job post.
 16. Job boards should be high quality, without paywalls, requiring login, etc.
 17. No agencies, please.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ If you're making a pull request, please ensure it adheres to the following guide
 
 1. Check if the link is working and pointing to the right location.
 2. Check your spelling and grammar.
-3. Choose the corresponding section.
+3. Choose the correct corresponding section.
 4. The list, after your addition, should be sorted alphabetically.
 5. Make an individual pull request for each suggestion.
 6. If you use a text editor to fashion the pull request, make sure your text editor is set to remove trailing whitespace.
@@ -19,10 +19,8 @@ If you're making a pull request, please ensure it adheres to the following guide
     For example, if one wants to find Python jobs, or to filter for US-only companies, the following descriptions would be useful:
     1. [Foo](foo.io) - We are building new certificate provider based on crypocurrencies. Python, Scala, JS, Full Time
     2. [Bar](bar.io) - Uber for fruit baskets. Node, grunt, JS, workday overlaps New York afternoons (1700 - 2200 UTC)
-13. Any new entry should have meaningful content at the time of the addition to this list
-    — we can't tell whether something is awesome if there is little to see.
-    As a rule of thumb, there should be at least about six months worth of content. 
-14. Companies should have "remote DNA".
+13. Any new entry should have meaningful content at the time of the addition to this list. We can't tell whether something is awesome if there is little to see. As a general rule, there should be at least about six months worth of content.
+14. Companies, if added, should have "remote DNA". This means they are not only remote friendly, but dedicated to remote work as a core of their business.
 15. Link to the career/job page rather than to a single job post.
 16. Job boards should be high quality, without paywalls, requiring login, etc.
 17. No agencies, please.
@@ -30,4 +28,3 @@ If you're making a pull request, please ensure it adheres to the following guide
 ## Dead Link Policy
 
 We check all links are valid with the awesome [awesome_bot](https://github.com/dkhamsing/awesome_bot). If links die, we remove them - this saves time for the maintainers, and ensures awesome links. We'd be happy to accept PRs to re-add new links.
-


### PR DESCRIPTION
This PR adds a PR template, and adds small changes to the Contributing guide. This closes #358. It should make it easier to close drive-by PRs, and ensure that we keep the list a bit higher quality by asking for descriptions and reasons why additions are truly _awesome_ up front.