### PR TITLE
Update TOC for #518

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 - [Articles & Posts](#articles--posts)
 - [Videos](#videos)
 - [Books](#books)
-- [Comics](#comics)
+- [Humor](#humor)
 - [Job boards](#job-boards)
 - [Job boards aggregators](#job-boards-aggregators)
 - [Housing](#housing)


### PR DESCRIPTION
The *Comics* section was renamed to *Humor* in 19da45390f273ba28e6a9d4ca533bb065fa62df3 but the table of contents was forgotten.