### PR TITLE
Whitelist angellist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ rvm: 2.2
 before_script:
   - gem install awesome_bot
 script:
-  - awesome_bot README.md --allow-ssl --allow-dupe --allow-redirect --white-list http://www.9punto5.cl,https://www.higheredjobs.com/search/remote.cfm,https://www.chegg.com/tutors/become-a-tutor/,https://jobs.drupal.org/home/type/telecommute-remote-3588,https://assoc.drupal.org/jobs
+  - awesome_bot README.md --allow-ssl --allow-dupe --allow-redirect --white-list http://www.9punto5.cl,https://www.higheredjobs.com/search/remote.cfm,https://www.chegg.com/tutors/become-a-tutor/,https://jobs.drupal.org/home/type/telecommute-remote-3588,https://assoc.drupal.org/jobs,https://angel.co/jobs

--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Scrapinghub](https://scrapinghub.com/jobs)
   1. [ServiceNow](http://jobs.jobvite.com/servicenow/search?c=&l=&r=&t=&q=remote) - Enterprise cloud computing to improve service levels, energize employees, and change the way your enterprise works. Work at lightspeed.
   1. [ShakaCode](http://www.shakacode.com/about/index.html#work-with-us) - A global web development software consultancy and product company.
+  1. [Shogun](https://getshogun.com/team) - Build and optimize eCommerce landing pages. Ruby / Rails, Go, JavaScript, React. 100% remote.
   1. [Signal](https://www.signal.org/workworkwork/) - These people make the fantastic [Signal app](https://www.signal.org). US Only.
   1. [Simple](https://www.simple.com/careers)
   1. [Skyscrapers](http://skyscrapers.eu/jobs/) - Cloud hosting services & management. Working with multiple cloud providers (AWS, Digital Ocean, Linode, ...). 100% remote.


### PR DESCRIPTION
What
Add `https://angel.co/jobs` to  whitelist

Why
`https://angel.co/jobs` is returning a `403` status code causing all Travis builds to fail. 

Comments
AngelList does resolve, and I don't think `angel.co` will be going anywhere so I think it's safe to whitelist
