### PR TITLE
Fix HR link in TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 - [Communities](#communities)
 - [Conferences](#conferences)
 - [Tools](#tools)
-  - [HR] (#hr)
+  - [HR](#hr)
   - [Communication](#communication)
   - [Project Management](#project-management)
   - [Others](#others)


### PR DESCRIPTION
Just a simple fix to the HR link in the table of contents
