### PR TITLE
Add findwork.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Zdalnie.io](https://zdalnie.io) Remote jobs in Poland and Europe
 
 ## Job boards aggregators
+  1. [Findwork](https://findwork.dev/) Crawls multiple job boards and enriches job postings with Glassdoor (reviews) and Crunchbase (funding).
   1. [Google Jobs](https://www.google.com/search?q=remote&ibp=htl;jobs#fpstate=tldetail&htidocid=IO0hI7dpKTSlzSKoAAAAAA%3D%3D&htin=1&htivrt=jobs)  – Aggregates from multiple boards and employer sites with sensitivity to location, job type, and more. Find out how to use it [here](https://support.google.com/websearch/answer/7498276?p=job_search_box&sa=X&ved=0ahUKEwid_qyLmJfXAhVD4YMKHYGBAK8Qra4CCGQoAQ&visit_id=1-636449234996681631-3229288694&rd=1).
   1. [GoRemote.io](https://goremote.io/)
   1. [JS Remotely](https://jsremotely.com/) - All remote JavaScript jobs on one board


### PR DESCRIPTION
https://findwork.dev

Crawls multiple job boards and enriches listings with Glassdoor (reviews) and Crunchbase (funding).