### PR TITLE
Remove a link to the discontinued zdalnie.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,6 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [We Work Remotely](https://weworkremotely.com/)
   1. [Workana](https://www.workana.com/) Freelance Job Board in Spanish and Portuguese
   1. [Working Nomads](http://www.workingnomads.co/jobs)
-  1. [Zdalnie.io](https://zdalnie.io) Remote jobs in Poland and Europe
 
 ## Job boards aggregators
   1. [Findwork](https://findwork.dev/) Crawls multiple job boards and enriches job postings with Glassdoor (reviews) and Crunchbase (funding).


### PR DESCRIPTION
Just remove a non-functional link.