### PR TITLE
Dotnetos added to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Discourse](https://www.discourse.org/team) - Civilized discussion for your community.
   1. [DNSimple](https://dnsimple.com) - Small 100% remote and globally distributed team working to make domain management an afterthought.
   1. [Doist](https://doist.com/jobs/) - Redefining productivity since 2007.
+  1. [Dotnetos](https://dotnetos.org/) - Dotnet performance conferences, meetups and courses.
   1. [Dotsub](https://dotsub.com/jobs) - Browser-based platform for subtitling & translating online videos. Java / Spring, JavaScript / React.js
   1. [Doximity](https://www.doximity.com/about/jobs) - Largest online medical network of US physicians. Ruby, Rails, Go, JavaScript, MySQL.
   1. [Drupal Association](https://assoc.drupal.org/jobs) - Non-profit supporting the Drupal project.


### PR DESCRIPTION
This PR adds [Dotnetos](https://dotnetos.org) to the list of companies with remote DNA.

It's a small company focused on sharing knowledge about dotnet performance via conferences, meetups, talks. Every member (so far) lives in a different city 😉 