### PR TITLE
Add Dynamite Jobs to Job Boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Daily Remote](https://dailyremote.com) Filter and find remote jobs for every role!
   1. [Dribbble Jobs](https://dribbble.com/jobs?location=Anywhere)
   1. [Drupal Jobs](https://jobs.drupal.org/home/type/telecommute-remote-3588)
+  1. [Dynamite Jobs](https://www.dynamitejobs.com/) - High quality, handpicked, and clearly shows whether job is WFA or region specific.
   1. [Europe Remotely](http://europeremotely.com/)
   1. [Find Bacon](https://findbacon.com) - Design and Dev jobs
   1. [Flexjobs](https://www.flexjobs.com/) – Telecommuting Jobs & Professional Part-Time Jobs.


### PR DESCRIPTION
Dynamite Jobs is curated like FlexJobs but free. On the main view it's clearly stated whether the job is work from anywhere (WFA) or region specific. Dozens of new remote jobs are added every day by the DJ team.

<!-- Thanks for adding a resource about remote work to this list! 🎉

Add the URL below -->



<!-- And then, explain what this URL adds and why it is awesome -->



<!-- Make sure your pull request follows the [Contribution Guidelines](CONTRIBUTING.md) before submitting! Thank you. -->
