### PR TITLE
Added kubejobs.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [JustRemote](https://justremote.co)
   1. [Landing.jobs](https://landing.jobs/offers) filter -> Remote only
   1. [Larajobs](https://larajobs.com/?location=&remote=1) – The artisan employment connection
+  1. [KubeJobs](https://kubejobs.io) - Hand-picked and curated Kubernetes jobs. Filter -> “*remote*”
   1. [No Fluff Jobs](https://nofluffjobs.com/#criteria=remote) – Filter -> “*remote*”
   1. [NODESK](https://nodesk.co/remote-jobs/)
   1. [Nonprofit Remote](https://nonprofitremote.com/) - A place where remote workers, volunteers, and nonprofits connect.


### PR DESCRIPTION
Added kubejobs.io - a job board specialising in Kubernetes positions.