### PR TITLE
Added Kube Careers

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Jobhunt.ai](https://jobhunt.ai/machinelearning-remote-jobs.html) – Machine learning jobs. Filter -> Remote only.
   1. [Jobspresso](https://jobspresso.co/) * High-quality remote positions that are open and legitimate *
   1. [JustRemote](https://justremote.co)
+  1. [Kube Careers](https://kube.careers) Kubernetes curated jobs with clear salary ranges and apply directly to companies.
   1. [Landing.jobs](https://landing.jobs/offers) filter -> Remote only
   1. [Larajobs](https://larajobs.com/?location=&remote=1) – The artisan employment connection
   1. [No Fluff Jobs](https://nofluffjobs.com/#criteria=remote) – Filter -> “*remote*”


### PR DESCRIPTION
https://kube.careers

Curated job board for Kubernetes jobs with:

- Clear salary ranges.
- Apply directly to companies.
- Only Kubernetes focussed.

We don't have a "remote" filter, but that will follow soon (we do list and prefer remote jobs, though).