### PR TITLE
Add Shopify

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [ServiceNow](https://jobs.jobvite.com/servicenow/search?c=&l=&r=&t=&q=remote) - Enterprise cloud computing to improve service levels, energize employees, and change the way your enterprise works. Work at lightspeed.
   1. [ShakaCode](https://www.shakacode.com/career/) - A global web development software consultancy and product company.
   1. [Shogun](https://getshogun.com/team) - Build and optimize eCommerce landing pages. Ruby / Rails, Go, JavaScript, React. 100% remote.
+  1. [Shopify](https://www.shopify.ca/careers) - Leading e-commerce platforms. Ruby on Rails, React, Typescript. 100% remote in Americas, EMEA (Europe, Middle-East, Asia)
   1. [Signal](https://www.signal.org/workworkwork/) - These people make the fantastic [Signal app](https://www.signal.org). US Only.
   1. [Simple](https://www.simple.com/careers)
   1. [Skyscrapers](https://skyscrapers.eu/jobs/) - Cloud hosting services & management. Working with multiple cloud providers (AWS, Digital Ocean, Linode, ...). 100% remote.


### PR DESCRIPTION
https://www.shopify.ca/careers

Shopify switched to a digital-first format last year committing to 100% of employees working remote permanently.