### PR TITLE
Add Company Web3.career

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,11 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Vue.js Jobs](https://vuejobs.com/) Find Vue.js jobs all around the world - Click on "Remote" tab.
   1. [React.js Jobs](https://www.react-jobs.com) Find React.js jobs all around the world - Click on "Remote" toggle button.
   1. [Remote.com](https://remote.com) - Tries to auto-match you with jobs, can import profile from LinkedIn
-  1. [We Love Go](https://www.welovegolang.com/) Find Go jobs and Go people all around the world - Click on "Remote Go jobs" link. #golang
-  1. [We Work Remotely](https://weworkremotely.com/)
-  1. [Workana](https://www.workana.com/) Freelance Job Board in Spanish and Portuguese
-  1. [Working Nomads](https://www.workingnomads.co/jobs)
+  2. [Web3Jobs](https://web3.career/remote-jobs) - Remote Web3 Jobs
+  3. [We Love Go](https://www.welovegolang.com/) Find Go jobs and Go people all around the world - Click on "Remote Go jobs" link. #golang
+  4. [We Work Remotely](https://weworkremotely.com/)
+  5. [Workana](https://www.workana.com/) Freelance Job Board in Spanish and Portuguese
+  6. [Working Nomads](https://www.workingnomads.co/jobs)
 
 ## Job boards aggregators
   1. [Bergamot](https://bergamot.io/) - Provides the widest selection of remote tech jobs by monitoring over 150,000 companies' career pages. Full-text search and AI-powered geo filter inside. Free, no sign-up required.


### PR DESCRIPTION
This is the first job board focused on Web3. It has 6230 jobs at 674 Projects and has paid customers like Stripe, Buildspace, ApeSwap, Metadrop and others.
