### PR TITLE
Add Remotewide.co

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,27 +177,28 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [remote-jobs](https://github.com/jessicard/remote-jobs) - A list of semi to fully remote-friendly companies in tech
   1. [Remotees](https://remotees.com/)
   1. [RemotExtra](https://www.remotextra.com/) - Remote developer jobs with transparent salaries
-  1. [Remote.co Jobs](https://remote.co/remote-jobs/)
-  1. [RemoteJobs.lat](https://remotejobs.lat/) -  Remote jobs for LATAM people
-  1. [Remotive Jobs](https://remotive.io/)
-  1. [Remote People](https://remotepeople.io/)
-  1. [Remote Works](https://remote.works-hub.com) - Remote jobs in software development
-  1. [Ruby On Remote](https://rubyonremote.com/) - All ruby remote jobs in one place
-  1. [Skip the Drive](https://www.skipthedrive.com/)
-  1. [Slasify](https://slasify.com/en/) - Remote tech, art/design and marketing opportunities from Asia, global payroll service included.
-  1. [Stack Overflow Jobs](https://stackoverflow.com/jobs/remote)
-  2. [Stream Native Jobs](https://streamnative.io/careers/) - Scroll down to `Join Us`
-  3. [SwissDev Jobs](https://swissdevjobs.ch/) - Filter -> "Remote / Work from home"
-  4. [Upwork](https://www.upwork.com) - Find remote jobs in any category
-  5. [Virtual Vocations](https://www.virtualvocations.com/)
-  6. [Vue.js Jobs](https://vuejobs.com/) Find Vue.js jobs all around the world - Click on "Remote" tab.
-  7. [React.js Jobs](https://www.react-jobs.com) Find React.js jobs all around the world - Click on "Remote" toggle button.
-  8. [Remote.com](https://remote.com) - Tries to auto-match you with jobs, can import profile from LinkedIn
-  9. [Web3Jobs](https://web3.career/remote-jobs) - Remote Web3 Jobs
-  10. [We Love Go](https://www.welovegolang.com/) Find Go jobs and Go people all around the world - Click on "Remote Go jobs" link. #golang
-  11. [We Work Remotely](https://weworkremotely.com/)
-  12. [Workana](https://www.workana.com/) Freelance Job Board in Spanish and Portuguese
-  13. [Working Nomads](https://www.workingnomads.co/jobs)
+  1. [Remotewide](https://remotewide.co/) - Find remote jobs with location independent pay.
+  3. [Remote.co Jobs](https://remote.co/remote-jobs/)
+  4. [RemoteJobs.lat](https://remotejobs.lat/) -  Remote jobs for LATAM people
+  5. [Remotive Jobs](https://remotive.io/)
+  6. [Remote People](https://remotepeople.io/)
+  7. [Remote Works](https://remote.works-hub.com) - Remote jobs in software development
+  8. [Ruby On Remote](https://rubyonremote.com/) - All ruby remote jobs in one place
+  9. [Skip the Drive](https://www.skipthedrive.com/)
+  10. [Slasify](https://slasify.com/en/) - Remote tech, art/design and marketing opportunities from Asia, global payroll service included.
+  11. [Stack Overflow Jobs](https://stackoverflow.com/jobs/remote)
+  12. [Stream Native Jobs](https://streamnative.io/careers/) - Scroll down to `Join Us`
+  13. [SwissDev Jobs](https://swissdevjobs.ch/) - Filter -> "Remote / Work from home"
+  14. [Upwork](https://www.upwork.com) - Find remote jobs in any category
+  15. [Virtual Vocations](https://www.virtualvocations.com/)
+  16. [Vue.js Jobs](https://vuejobs.com/) Find Vue.js jobs all around the world - Click on "Remote" tab.
+  17. [React.js Jobs](https://www.react-jobs.com) Find React.js jobs all around the world - Click on "Remote" toggle button.
+  18. [Remote.com](https://remote.com) - Tries to auto-match you with jobs, can import profile from LinkedIn
+  19. [Web3Jobs](https://web3.career/remote-jobs) - Remote Web3 Jobs
+  20. [We Love Go](https://www.welovegolang.com/) Find Go jobs and Go people all around the world - Click on "Remote Go jobs" link. #golang
+  21. [We Work Remotely](https://weworkremotely.com/)
+  22. [Workana](https://www.workana.com/) Freelance Job Board in Spanish and Portuguese
+  23. [Working Nomads](https://www.workingnomads.co/jobs)
 
 ## Job boards aggregators
   1. [Bergamot](https://bergamot.io/) - Provides the widest selection of remote tech jobs by monitoring over 150,000 companies' career pages. Full-text search and AI-powered geo filter inside. Free, no sign-up required.
@@ -218,7 +219,6 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Work Remotely](https://workremotely.io/) - Crawls and curates many job board feeds for remote positions
   1. [Workaline](https://workaline.com/) - Remote jobs aggregator. Formerly called Alfred.
   1. [Wrk.ist](https://wrk.ist/) - latest remote jobs in your console (curl)
-  1. [Remotewide](https://remotewide.co/) - Find remote jobs with location independent pay.
 
 ## Housing
   1. [Agora space](http://www.agora-space.com/) - Coworking & coliving space in Shanghai in China

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Work Remotely](https://workremotely.io/) - Crawls and curates many job board feeds for remote positions
   1. [Workaline](https://workaline.com/) - Remote jobs aggregator. Formerly called Alfred.
   1. [Wrk.ist](https://wrk.ist/) - latest remote jobs in your console (curl)
+  1. [Remotewide](https://remotewide.co/) - Find remote jobs with location independent pay.
 
 ## Housing
   1. [Agora space](http://www.agora-space.com/) - Coworking & coliving space in Shanghai in China


### PR DESCRIPTION
<!-- Thanks for adding a resource about remote work to this list! 🎉

Add the URL below -->
https://remotewide.co/



<!-- And then, explain what this URL adds and why it is awesome -->
Remotewide.co is the only job board that exclusively features jobs with location independent pay.


<!-- Make sure your pull request follows the [Contribution Guidelines](CONTRIBUTING.md) before submitting! Thank you. -->
