### PR TITLE
Add remote developers' community - Invide

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 1. [Remote Indian](https://remoteindian.com/) - Remote workers from India.
 1. [Eleduck](https://eleduck.com) - A remote worker community in China(来自中国的远程工作社区).
 1. [Hypelance](https://hypelance.com/) - Digital Community Forum for Freelancers and Entrepreneurs.
+1. [Invide](https://invidelabs.com/developer.html) - Invite-only community of experienced remote developers since 2016. Also has a [public discord community](https://dsc.gg/invide) for newbies.
 
 ## Conferences
  1. [DNX Global](https://www.dnxfestival.com/) - Digital Nomad Conference.


### PR DESCRIPTION
[Invide - A remote developers' community](https://invidelabs.com/developer.html)


Invide is a community of developers from remote areas(rural areas, tier 2-3 cities, etc.). Since 2016, Invide community has been providing support to devs to grow in career. It is free. 
To make sure the community members have great experience, it is invite-based and has some moderation for new members. But to make sure that newbies in remote work get proper guidance and become eligible for this invite-only community, it also has a [public discord community](https://dsc.gg/invide).