### PR TITLE
Add pyjobs.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [No Fluff Jobs](https://nofluffjobs.com/#criteria=remote) – Filter -> “*remote*”
   1. [NODESK](https://nodesk.co/remote-jobs/)
   1. [Power to Fly](https://powertofly.com/jobs/) - Specific to women
+  1. [PyJobs.com](https://www.pyjobs.com/?remoteLevel[0]=1&remoteLevel[1]=2) - Jobs for Python developers
   1. [Remote Game Jobs](https://remotegamejobs.com/) - Find remote work and talent in the game industry.
   1. [remote-es/remotes](https://github.com/remote-es/remotes) - Repository listing companies which offer full-time remote jobs with Spanish contracts
   1. [remote-jobs](https://github.com/jessicard/remote-jobs) - A list of semi to fully remote-friendly companies in tech


### PR DESCRIPTION
[PyJobs.com](https://www.pyjobs.com/?remoteLevel[0]=1&remoteLevel[1]=2&remoteLevel[2]=3) is a job board for python developers, where visitors can filter by remote work type, such as "full remote", "hybrid", etc...