### PR TITLE
Add RemoteScout to jobboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [remote-es/remotes](https://github.com/remote-es/remotes) - Repository listing companies which offer full-time remote jobs with Spanish contracts
   1. [remote-jobs](https://github.com/jessicard/remote-jobs) - A list of semi to fully remote-friendly companies in tech
   1. [Remotees](https://remotees.com/)
+  1. [RemoteScout](https://remotescout.ch/) - Remote and hybrid jobs in Germany, Austria and Switzerland
   1. [RemotExtra](https://www.remotextra.com/) - Remote developer jobs with transparent salaries
   1. [Remote.co Jobs](https://remote.co/remote-jobs/)
   1. [RemoteJobs.lat](https://remotejobs.lat/) -  Remote jobs for LATAM people


### PR DESCRIPTION
<!-- Thanks for adding a resource about remote work to this list! 🎉

Add the URL below -->
[remotescout.ch](https://remotescout.ch)


<!-- And then, explain what this URL adds and why it is awesome -->
RemoteScout is a jobboard with remote and hybrid jobs in Germany, Austria and Switzerland. As IT Jobs in this area are usually well paid (Specially in Switzerland) I thought this might be a good resource for this list.


<!-- Make sure your pull request follows the [Contribution Guidelines](CONTRIBUTING.md) before submitting! Thank you. -->
