### PR TITLE
Add a useful mock interview website

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   8. [skillmeter.com](https://skillmeter.com/) - Online skills testing platform for recruiters & companies
   9. [hackerrank.com](https://www.hackerrank.com/) - Online platform for code studying and recruiting with job offers also
   10. [Codility](https://www.codility.com/) - Online platform that offers sponsored challenges
+  11. [Meetapro](https://meetapro.com/?utm_source=arjgithub) - Airbnb-style Mock interviews with experienced FAANG interviewers
 
 ## Events
   1. [deceler8](https://sierraymar.exposure.co/decelerate-bali) - 10 days retreat


### PR DESCRIPTION
<!-- Thanks for adding a resource about remote work to this list! 🎉

Add the URL below -->

https://meetapro.com

<!-- And then, explain what this URL adds and why it is awesome -->

Envision Meetapro as the Airbnb for mock interviews and career coaching. It connects job seekers with seasoned FAANG interviewers who provide invaluable feedback, getting you ready for real-life interviews. Numerous job seekers have already reaped the benefits of this platform.

What makes Meetapro stand out?
- Affordability: The average cost per session is significantly lower compared to other platforms.
- Expert interviewers: Veterans from FAANG and top-tier companies bring years of experience, offering priceless feedback that truly makes a difference.
- Direct communication: Job seekers can directly message interviewers to address any questions or concerns, such as experience sharing or rescheduling, ensuring better preparation for both parties.
- All-in-one tools: Meetapro equips you with the essential tools for an effective interview session, including recording options for post-session review.


<!-- Make sure your pull request follows the [Contribution Guidelines](CONTRIBUTING.md) before submitting! Thank you. -->
