### PR TITLE
fix/remove remotextra.com from the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,6 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [remote-es/remotes](https://github.com/remote-es/remotes) - Repository listing companies which offer full-time remote jobs with Spanish contracts
   1. [remote-jobs](https://github.com/jessicard/remote-jobs) - A list of semi to fully remote-friendly companies in tech
   1. [Remotees](https://remotees.com/)
-  1. [RemotExtra](https://www.remotextra.com/) - Remote developer jobs with transparent salaries
   1. [Remotewide](https://remotewide.co/) - Find remote jobs with location independent pay
   1. [Remote.co Jobs](https://remote.co/remote-jobs/)
   1. [RemoteJobs.lat](https://remotejobs.lat/) -  Remote jobs for LATAM people


### PR DESCRIPTION
<!-- Thanks for adding a resource about remote work to this list! 🎉

Add the URL below -->



<!-- And then, explain what this URL adds and why it is awesome -->



<!-- Make sure your pull request follows the [Contribution Guidelines](CONTRIBUTING.md) before submitting! Thank you. -->

Hey there
I was remove the www.remotextra.com link from the list cause it's redirecting to some scam/spam website
It's not conveniently. please consider to merge this pull request
ref issues: https://github.com/lukasz-madon/awesome-remote-job/issues/820
Thanks
