### PR TITLE
Add European Remote to the Newsletters section

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,14 +263,16 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 
 ## Newsletters
   1. [Daily Remote](https://dailyremote.com/newsletter) - A newsletter containing remote jobs crafted and curated especially for you
+  2. [European Remote](https://europeanremote.com/alerts) - Selected opportunities for European tech folks, every week in your inbox
   1. [Figures](https://joinfigures.com) - Set your salary requirement and receive remote jobs that pay more
   1. [Making Remote Work](https://www.mailerlite.com/remote-newsletter) - MailerLite's monthly remote newsletter sharing best practices, mistakes and learnings, world views (quite literally) and remote job vacancies.
   1. [NODESK](https://nodesk.co/) - A newsletter about digital nomads and remote work that is sent out every two weeks.
   1. [Remote Internships](https://smash.vc/startup-newsletter/)
+  1. [Remote Jobs Club](https://remotejobsclub.com) - Weekly newsletter featuring a hand curated list of remote jobs
   1. [Remoteur](http://www.remoteur.com) - Remote jobs in Europe delivered to your inbox bi-weekly
   1. [Remotive - productive remote workers](https://remotive.io/) - A weekly newsletter on Remote Tips & Jobs sent to 10,000+ Remote Workers
   1. [Yonder Newsletter](https://yonder.io/newsletter) - Daily remote work tips, links, articles, and the Yonder Podcast
-  1. [Remote Jobs Club](https://remotejobsclub.com) - Weekly newsletter featuring a hand curated list of remote jobs
+  
 
 ## Podcasts
   1. [Building Remote Teams](https://www.buildingremoteteams.com/) - Targeted at people already working remotely and focuses on nuanced challenges of remote work.


### PR DESCRIPTION
- Fix alphabetical order in newsletters
- Add European Remote with description

<!-- Thanks for adding a resource about remote work to this list! 🎉

Add the URL below -->

[European Remote - newsletter](https://europeanremote.com)

<!-- And then, explain what this URL adds and why it is awesome -->

This allows you to subscribe to the selected remote opportunities available for European folks.
The jobs are curated by the tech stack and sent weekly. We're getting them outside of the major hiring platforms, which gives a unique variety of options available. 

All in all, we're focused on the product companies only, but when it comes to scale both VC-backed companies and bootstrapped ones are included.

<!-- Make sure your pull request follows the [Contribution Guidelines](CONTRIBUTING.md) before submitting! Thank you. -->
