### PR TITLE
Add slashjobs.com to 'Job boards aggregators'

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Remote Leaf](https://remoteleaf.com) - Hand-picked remote jobs from 40+ remote job boards, 1500+ company career pages, Twitter feed, Linkedin, Reddit, Hacker News Hiring and only sends the ones that apply to you.
   1. [Remote OK](https://remoteok.io/) - Scrapes many job board feeds for remote positions.
   1. [Remote Python](https://www.remotepython.com/) - Job board and aggregator specifically for remote Python jobs.
+  1. [SlashJobs](https://slashjobs.com/) - Remote dev jobs aggregator. `and`/`or`/`not` filters, location search, fast, no sign-up/login.
   1. [UN Talent](https://untalent.org/jobs/home-based) - Vacancies at the United Nations and its agencies.
   1. [Vollna](https://www.vollna.com/) - An aggregator for top freelance sites.
   1. [whoishiring.io](https://whoishiring.io/#!/search/19.41/-43.14/2/?remote=true)


### PR DESCRIPTION
An aggregator specifically for remote devs looking for long-term positions. Listings are pulled from popular job boards and are enriched with additional metadata (not available in the original listings) that's exposed in search filters.

Some differentiating factors:
- And/or/not filters and filter groups are available for all metadata
- Shortlist and notes with multiple devices sync and txt export
- "Jobs added since last visit" indicator
- No analytics/login/sign-ups
- Fast (SSR'ed and cached)
- Dead/fulfilled listings are automatically expired (removed from the main page and `noindex`ed)

Thanks!

<!-- Thanks for adding a resource about remote work to this list! 🎉

Add the URL below -->



<!-- And then, explain what this URL adds and why it is awesome -->



<!-- Make sure your pull request follows the [Contribution Guidelines](CONTRIBUTING.md) before submitting! Thank you. -->
