### PR TITLE
Adds Django On Remote job board

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [zuhausejobs.com](https://zuhausejobs.com) - Remote Jobs in German-speaking countries (Germany/Austria/Switzerland)
   1.  [Dataaxy](https://dataaxy.com) Job board and reverse job board specialized in Data and AI in North America
   1.  [Freel](https://freel.ca) Freelancers job board in Canada
+  1.  [Django On Remote](https://django.on-remote.com/) Handpicked, remote only Django opportunities
 ## Job boards aggregators
   1. [Career Vault](https://www.careervault.io) - Hundreds of remote jobs added each day from thousands of company career pages. Free and no signup required.
   1. [Findwork](https://findwork.dev/) Crawls multiple job boards and enriches job postings with Glassdoor (reviews) and Crunchbase (funding).


### PR DESCRIPTION
https://django.on-remote.com/

It's just very useful for Django developers.