### PR TITLE
Add Company bilstein group

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [BaseCamp](https://basecamp.com/about/team) - Project management software.
   1. [Baselayer](https://www.baselayer.com/company/careers/) - Data center and infrastructure management software.
   1. [BeBanjo](https://bebanjo.com/careers/) - Software as a service for managing video on-demand. Ruby / Rails, Elasticsearch, Sidekiq.
+  1. [Bilsteingroup](https://bilsteingroup.com/en/career/) - Automotive spare parts. Python, Java, Postgres. Teams accross Europe. HQ in Germany.
   1. [Binti](https://binti.com/current-openings/) - Foster care.
   1. [Bluespark Labs](https://www.bluespark.com/careers) - WebDev Consulting and makers of Roomify. Remote team with HQs in Raleigh, NC and Italy. Drupal.
   1. [Blend](https://blend.com/company/careers/) - Fintech.


### PR DESCRIPTION
Added german remote company bilstein group

https://bilsteingroup.com/en

The bilstein group is global acting supplier and manufacturer for automotive spare parts. It's well known for its innovative digital solutions in the IAM sector. Software developer teams work remotely together.

Disclaimer: I'm working for this company. In case you have any questions towards our team, culture, jobs or remote offerings, let me know.