### PR TITLE
Change Pramp to Exponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [adaface.com/pair-pro](https://www.adaface.com/pair-pro) - Remote pair programming interview tool with shared editor, code compiler and video conferencing
   1. [interviewing.io](https://interviewing.io/) - Become awesome at technical interviews
   1. [karat.io](https://karat.com/) - Have a free practice coding interview with a professional interviewer
-  1. [pramp](https://pramp.com) - Practice coding interviews (both sides of the table) with other candidates
+  1. [exponent](https://www.tryexponent.com) - Practice coding interviews (both sides of the table) with other candidates
   1. [remoteinterview.io](https://www.remoteinterview.io/) - Coding tests & pair programming interview tools
   1. [skillmeter.com](https://skillmeter.com/) - Online skills testing platform for recruiters & companies
   1. [hackerrank.com](https://www.hackerrank.com/) - Online platform for code studying and recruiting with job offers also


### PR DESCRIPTION
[Pramp recently changed to Exponent as of June 2024](https://blog.pramp.com/pramp-is-now-exponent-practice-improved-peer-mock-interviews-d05b9d3abde1), the current [pramp.com](https://www.pramp.com/#/) website redirects users to exponent.com

_note: in the original commit note from my branch I accidentally called it pramp.io by accident, my apologies! (doesn't affect anything)_



<!-- Thanks for adding a resource about remote work to this list! 🎉

Add the URL below -->



<!-- And then, explain what this URL adds and why it is awesome -->



<!-- Make sure your pull request follows the [Contribution Guidelines](CONTRIBUTING.md) before submitting! Thank you. -->
