### PR TITLE
Add Remote Job Zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [zuhausejobs.com](https://zuhausejobs.com) - Remote Jobs in German-speaking countries (Germany/Austria/Switzerland)
   1.  [Dataaxy](https://dataaxy.com) Job board and reverse job board specialized in Data and AI in North America
   1.  [Freel](https://freel.ca) Freelancers job board in Canada
+  1.  [Remote Job Zone](https://www.remotejobzone.online/open-jobs) Worldwide remote jobs for software engineers
 ## Job boards aggregators
   1. [Career Vault](https://www.careervault.io) - Hundreds of remote jobs added each day from thousands of company career pages. Free and no signup required.
   1. [Findwork](https://findwork.dev/) Crawls multiple job boards and enriches job postings with Glassdoor (reviews) and Crunchbase (funding).


### PR DESCRIPTION
https://www.remotejobzone.online/open-jobs 
Worldwide jobs are posted daily and authenticated manually. We post jobs for software engineers mostly.

<!-- Thanks for adding a resource about remote work to this list! 🎉

Add the URL below -->

https://www.remotejobzone.online/open-jobs

<!-- And then, explain what this URL adds and why it is awesome -->

We post remote jobs on our board from all over the world and specify the correct information about the jobs as they are posted manually. 

<!-- Make sure your pull request follows the [Contribution Guidelines](CONTRIBUTING.md) before submitting! Thank you. -->
