### PR TITLE
awesome_bot now allows 403 errors in workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,4 +20,4 @@ jobs:
     - name: Checks
       run: |
         gem install awesome_bot
-        awesome_bot README.md --allow-ssl -a 302,429,502 -w xbmc/xbmc,swiftui/fruta
+        awesome_bot README.md --allow-ssl -a 302,429,502,403 -w xbmc/xbmc,swiftui/fruta


### PR DESCRIPTION
@RichardLitt This should be mergeable.

This stops awesome_bot from flagging websites that respond with 403, as those flagged links work when accessed with a browser and not the awesome_bot script.