### PR TITLE
add findjobit.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Diversify Tech](https://www.diversifytech.com/job-board) - Companies are transparent about their Diversity & Inclusion efforts 
   1. [Dribbble Jobs](https://dribbble.com/jobs?location=Anywhere)
   1. [Drupal Jobs](https://jobs.drupal.org/home/type/telecommute-remote-3588)
+  1. [Findjobit](https://findjobit.com/jobs) - Remote jobs for LATAM IT professionals.
   1. [freelancermap](https://www.freelancermap.com/projects/remote.html) - Freelance & contract jobs for IT experts (mostly German projects)
   1. [Golangprojects](https://www.golangprojects.com/golang-remote-jobs.html) filter -> Remote only
   1. [Guru](https://www.guru.com/) - (has MANY different categories outside software)


### PR DESCRIPTION
https://findjobit.com/jobs

This URL links to [Findjobit](https://findjobit.com/jobs/)'s job board, which lists open remote positions for Latam IT professionals.

Findjobit is a providing a free posting service for Latam tech job roles, every other job board aiming for the same audience charge a fee, so it is hard for Latam people to search for jobs in several different job boards.