### PR TITLE
Add Jobboard NextGenEnergyJobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Jobspresso](https://jobspresso.co/) * High-quality remote positions that are open and legitimate *
   1. [JustRemote](https://justremote.co)
   1. [Larajobs](https://larajobs.com/?location=&remote=1) – The artisan employment connection
+  1. [NextGenEnergyJobs](https://www.nextgenenergyjobs.com/remote-jobs) – Remote Renewable Energy Jobs
   1. [No Fluff Jobs](https://nofluffjobs.com/pl/#criteria=remote) – Filter -> “*remote*”
   1. [NODESK](https://nodesk.co/remote-jobs/)
   1. [Power to Fly](https://powertofly.com/jobs/) - Specific to women


### PR DESCRIPTION
Adding the jobboard [https://www.nextgenenergyjobs.com/remote-jobs](https://www.nextgenenergyjobs.com/remote-jobs)

NextGenEnergyJobs is a jobboard dedicated to renewable energy sector. Currently is no jobboard in this domain listed on awesome-remote-job. With the current situation it is more important than ever to push renewables.