### PR TITLE
add remoteliz

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [UN Talent](https://untalent.org/jobs/home-based) - Vacancies at the United Nations and its agencies.
   1. [Vollna](https://www.vollna.com/) - An aggregator for top freelance sites.
   1. [whoishiring.io](https://whoishiring.io/#!/search/19.41/-43.14/2/?remote=true)
+  1. [RemoteLiz](https://www.remoteliz.com) - A remote search engine that actually crawls the web to find the job.
 
 ## Housing
   1. [bedndesk](https://www.bedndesk.com/) - Coworking & coliving space in Mallorca island in Spain


### PR DESCRIPTION
<!-- Thanks for adding a resource about remote work to this list! 🎉

Add the URL below -->

https://www.remoteliz.com


<!-- And then, explain what this URL adds and why it is awesome -->

RemoteLiz is a search engine crawls career sites of the companies. Currently, 400+ companies were added and it is counting up. The context is examined with AI and checked sources on the backend. The site has a login popup but there is a link to bypass. 


<!-- Make sure your pull request follows the [Contribution Guidelines](CONTRIBUTING.md) before submitting! Thank you. -->
