### PR TITLE
Add EmbeddedJobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1.  [Freel](https://freel.ca) Freelancers job board in Canada
   1.  [DevOpsJobs](https://devopsprojectshq.com) DevOps, SRE, Cloud and Platform engineering jobs
   1. [UI/UX Jobs Board](https://uiuxjobsboard.com/design-jobs/remote) - Remote jobs for UI/UX designers
+  1. [EmbeddedJobs](https://embedded.jobs) — Remote job board dedicated to embedded systems engineers and developers.
+
+
 ## Job boards aggregators
   1. [Career Vault](https://careervault.io/) - Hundreds of remote jobs added each day from thousands of company career pages. Free and no signup required.
   1. [Findwork](https://findwork.dev/) Crawls multiple job boards and enriches job postings with Glassdoor (reviews) and Crunchbase (funding).


### PR DESCRIPTION
Adds EmbeddedJobs to remote job boards section

<!-- Thanks for adding a resource about remote work to this list! 🎉

Add the URL below -->

https://embedded.jobs

<!-- And then, explain what this URL adds and why it is awesome -->

EmbeddedJobs is a niche job board focused on remote opportunities for embedded systems engineers and developers.  
It curates high-quality listings in embedded software and hardware engineering, making it easier for professionals in this specialized field to find relevant remote roles.

<!-- Make sure your pull request follows the [Contribution Guidelines](CONTRIBUTING.md) before submitting! Thank you. -->
