### PR TITLE
Add CreativeFuego Jobs to remote  job board section

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Authentic Jobs](https://authenticjobs.com/?search_location=remote)
   1. [Built In](https://builtin.com/jobs/remote)
   1. [ClojureJobboard.com](https://clojurejobboard.com/remote-clojure-jobs.html)- Clojure jobs, filter -> Remote only
+  1. [CreativeFuego Jobs](https://creativefuego.com/jobs?mode=remote) - Find the latest remote creative jobs from all over the globe.
   1. [Crypto Jobs](https://crypto.jobs/?jobs=remote) - Blockchain jobs for crypto enthusiasts.
   1. [Crypto Jobs List](https://cryptojobslist.com/remote) - #1 job board to find and post crypto, bitcoin and blockchain jobs.
   1. [Cryptocurrency Jobs](https://cryptocurrencyjobs.co/remote/) - Location filter -> *Remote*
@@ -597,3 +598,4 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 [![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, [Lukasz Madon](https://github.com/lukasz-madon) has waived all copyright and related or neighboring rights to this work.
+


### PR DESCRIPTION
Add CreativeFuego Jobs (https://creativefuego.com/jobs?mode=remote) to the job boards section.

CreativeFuego Jobs specializes in remote creative positions and aggregates  opportunities from around the world, making it a valuable resource for  creative professionals seeking remote work.

<!-- Thanks for adding a resource about remote work to this list! 🎉

Add the URL below -->



<!-- And then, explain what this URL adds and why it is awesome -->



<!-- Make sure your pull request follows the [Contribution Guidelines](CONTRIBUTING.md) before submitting! Thank you. -->
