### PR TITLE
add job.careers to job boards aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [UN Talent](https://untalent.org/jobs/home-based) - Vacancies at the United Nations and its agencies.
   1. [Vollna](https://www.vollna.com/) - An aggregator for top freelance sites.
   1. [whoishiring.io](https://whoishiring.io/#!/search/19.41/-43.14/2/?remote=true)
+  1. [Job&Careers](https://job.careers) — First Job Board Share Free Remote jobs from ATS like greenhouse, Lever, Workable etc, clean design and no login required.
 
 ## Housing
   1. [bedndesk](https://www.bedndesk.com/) - Coworking & coliving space in Mallorca island in Spain
@@ -597,3 +598,4 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 [![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, [Lukasz Madon](https://github.com/lukasz-madon) has waived all copyright and related or neighboring rights to this work.
+


### PR DESCRIPTION
job&careers is the first job board share free remote jobs from ATS like greehouse, lever, workable etc, clean design and no login required

<!-- Thanks for adding a resource about remote work to this list! 🎉

Add the URL below -->

https://job.careers

<!-- And then, explain what this URL adds and why it is awesome -->

It's totally free and remotely, with clean design and no ads, no login required, update hundreds of remote jobs everyday

<!-- Make sure your pull request follows the [Contribution Guidelines](CONTRIBUTING.md) before submitting! Thank you. -->
