### PR TITLE
add devtooljobs.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Cryptocurrency Jobs](https://cryptocurrencyjobs.co/remote/) - Location filter -> *Remote*
   1. [CyberJobHunt.in](https://cyberjobhunt.in/) - Explore Cyber Security Jobs in top Companies and Startups. 
   1. [Daily Remote](https://dailyremote.com) Filter and find remote jobs for every role!
+  1. [devtooljobs](https//devtooljobs.com/) - GTM jobs in dev tooling companies. For remote jobs, just filter it in search and, for better results, choose the country you're located in.
   1. [Diversify Tech](https://www.diversifytech.com/job-board) - Companies are transparent about their Diversity & Inclusion efforts 
   1. [Dribbble Jobs](https://dribbble.com/jobs?location=Anywhere)
   1. [Drupal Jobs](https://jobs.drupal.org/home/type/telecommute-remote-3588)


### PR DESCRIPTION
<!-- Thanks for adding a resource about remote work to this list! 🎉

Add the URL below -->

https://devtooljobs.com/

<!-- And then, explain what this URL adds and why it is awesome -->

devtooljobs.com is an aggregator for GTM jobs in dev tooling companies. We get them by scraping the companies' job page and essentially want to avoid having the two-sided marketplace problem, but rather be helpful to the people searching for a job. At the moment there are around 4.5k jobs, updated daily (no outdated jobs and takes max 24h to add a new job) and highly curated. 

<!-- Make sure your pull request follows the [Contribution Guidelines](CONTRIBUTING.md) before submitting! Thank you. -->
