### PR TITLE
chore: Update outdated GitHub Actions version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Ruby 2.6
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
- [x] Explained the change: This PR updates the `actions/checkout` action from version `v3` to `v6`, enhancing compatibility and features.  
- [x] Specified testing: The changes will be tested in the CI pipeline of the pull request.