### PR TITLE
Add Brighten to HR section

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 ## Tools
 
 #### HR
-  1. [Brighten](https://hellobrighten.com) – AI-powered employee recognition and onboarding for remote teams.
+  1. [Brighten](https://hellobrighten.com) – AI-powered peer recognition for remote teams — kudos, badges, and a rewards marketplace.
   1. [Remoteteam.com](https://gusto.com) – Automated payrolls, time off, HR tools, and compliance for remote companies.
 
 #### Communication

--- a/README.md
+++ b/README.md
@@ -526,6 +526,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 ## Tools
 
 #### HR
+  1. [Brighten](https://hellobrighten.com) – AI-powered employee recognition and onboarding for remote teams.
   1. [Remoteteam.com](https://gusto.com) – Automated payrolls, time off, HR tools, and compliance for remote companies.
 
 #### Communication


### PR DESCRIPTION
Added [Brighten](https://hellobrighten.com) to the HR tools section.

Brighten is an AI-powered peer recognition platform for remote and distributed teams. It helps remote companies build recognition culture with peer kudos, badges, leaderboards, and a rewards marketplace — all free for teams up to 10 users.

- Inserted in alphabetical order per contribution guidelines
- Format follows `[Name](link) – Description.` pattern
- Name + description is under 100 characters