### PR TITLE
Add Tribe - remote-first embedded recruiting for European tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Tortuga Backpacks](https://www.tortugabackpacks.com/pages/careers) - Backpacks for city travel.
   1. [Transloadit](https://transloadit.com/jobs/) - The world's most versatile file uploading & encoding service, since 2009, by devs for devs
   1. [Trello](https://trello.com/jobs)
+  1. [Tribe](https://www.tribexyz.com/careers) - Embedded recruiting for European tech companies. Fully remote team of 100+ across Europe.
   1. [TRM labs](https://www.trmlabs.com/careers)
   1. [Truelogic](https://www.truelogic.io/careers) - Outsourcing company focused on Latin America talent for US companies
   1. [Tyk](https://tyk.io/current-vacancies/) - API Gateway and API Management. Built with Go, open source.
@@ -598,4 +599,5 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 [![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, [Lukasz Madon](https://github.com/lukasz-madon) has waived all copyright and related or neighboring rights to this work.
+
 


### PR DESCRIPTION
Added Tribe, a remote-first recruiting team embedded within European tech companies, with 100+ fully remote staff across multiple countries

<!-- Thanks for adding a resource about remote work to this list! 🎉

Add the URL below -->

https://www.tribexyz.com/careers

<!-- And then, explain what this URL adds and why it is awesome -->

[Tribe](https://www.tribexyz.com/careers) - Remote-first recruiting team embedded within European tech companies. 100+ fully remote.

<!-- Make sure your pull request follows the [Contribution Guidelines](CONTRIBUTING.md) before submitting! Thank you. -->
