### PR TITLE
Add 4DayJob

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 ## Job boards
   1. [Real Work From Anywhere](https://www.realworkfromanywhere.com/) - A site for fully location independent jobs. All jobs on the site are 100% work from anywhere.
   1. [4 Day Week](https://4dayweek.io) - Software jobs with a better work / life balance.
+  1. [4DayJob](https://4dayjob.com/) - 4-day work week and remote jobs. 1,500+ flexible positions.
   1. [Authentic Jobs](https://authenticjobs.com/?search_location=remote)
   1. [Built In](https://builtin.com/jobs/remote)
   1. [ClojureJobboard.com](https://clojurejobboard.com/remote-clojure-jobs.html)- Clojure jobs, filter -> Remote only


### PR DESCRIPTION
Add [4DayJob](https://4dayjob.com/) to the Job boards section.

**Why it's different from existing entries:**
4DayJob is specifically dedicated to 4-day work week positions (not just remote jobs). While '4 Day Week' (4dayweek.io) focuses on software jobs, 4DayJob covers all industries with 1,500+ positions including non-tech roles. It's a free, no-login-required board with no paywall.

- Link is working and has active job listings
- Sorted alphabetically (after '4 Day Week')
- No login/paywall required
- Description follows the Name - Description format under 100 characters