### PR TITLE
Add AI Interview Coach for Engineering Leaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   - [Housing](#housing)
   - [Relocation Incentives](#relocation-incentives)
   - [Interviewing](#interviewing)
+- [AI Interview Coach](https://em-tools.io/interview-prep) - Voice-based AI behavioral interview practice for engineering managers and software engineers. 130+ role-specific questions, STAR-format scoring, and 3 interviewer personas.
   - [Events](#events)
   - [Newsletters](#newsletters)
   - [Podcasts](#podcasts)


### PR DESCRIPTION
## Add AI Interview Coach for Engineering Leaders

[AI Interview Coach](https://em-tools.io/interview-prep) - Voice-based AI behavioral interview practice built for software engineers and engineering managers. 130+ role-specific questions, STAR-format scoring across 6 dimensions, probing follow-ups, and 3 interviewer personas (Startup CTO, Big Tech VP, Scale-up Director). Free first question.