### PR TITLE
Add Your Tax Base to Law & Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecommuting) resources.
 
-*To contribute, click README.md and then the pencil icon. Make your changes and click the "Propose file change" button to submit a pull request. Make sure to follow [the contributions guidelines](CONTRIBUTING.md).*
+*To contribute, click README.md and then the pencil icon. Make your changes and click the "Propose file change" button to submit a pull request. Make sure to follow [the contributions guidelines](CONTRIBUTING.md).
 
 ## Table of Contents
 
@@ -579,7 +579,8 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Timing](https://timingapp.com/?lang=en) - Automatic time and productivity tracking for Mac. Helps you stay on track with your work (especially important when working remotely). Also ensures that no billable hours get lost if you are billing hourly (Mac).
 
 ## Law & Finance
-  1. [1099 contractors](https://www.smartcapitalmind.com/what-is-a-1099-contractor.htm) – US based companies can hire remote workers as.
+  [1099 contractors](https://www.smartcapitalmind.com/what-is-a-1099-contractor.htm) – US based companies can hire remote workers as.
+  1. [Your Tax Base](https://yourtaxbase.com/) - Florida residency and tax domicile services for digital nomads and remote workers, with virtual mailbox, Declaration of Domicile filing, and step-by-step guidance for establishing a tax-free home base.
   1. [Transferwise](https://wise.com/gb/business/payouts) - Easy way to pay remote employees.
 
 ## Others
@@ -598,4 +599,5 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 [![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, [Lukasz Madon](https://github.com/lukasz-madon) has waived all copyright and related or neighboring rights to this work.
+
 


### PR DESCRIPTION
Adding [Your Tax Base](https://yourtaxbase.com/) to the Law & Finance section.

**URL:** https://yourtaxbase.com/

**What it does:** Your Tax Base helps digital nomads, remote workers, expats, travel nurses, and RVers establish Florida residency and tax domicile. The service includes a virtual mailbox, Declaration of Domicile filing, and step-by-step guidance for setting up a tax-free home base - all done online without needing to visit Florida in person.

This is relevant to the Law & Finance section because establishing legal residency and tax domicile is a critical step for remote workers who want to optimize their tax situation while working from anywhere.