### PR TITLE
Add HeyRobyn to Communication tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Fleep](https://fleep.io/) - Internal chat and collaboration tool for development teams
   1. [Floobits](https://floobits.com) - Remote pair programming with screen share. Integrates with Sublime, IntelliJ, Atom and others
   1. [Gather](https://www.gather.town/) - Gather is a video-calling space that lets multiple people hold separate conversations in parallel, walking in and out of those conversations just as easily as they would in real life.
+  1. [HeyRobyn](https://heyrobyn.ai) - Native Mac unified inbox for email, Slack, and GitHub in one window. Helps remote teams manage communication across multiple channels.
   1. [IRCCloud](https://www.irccloud.com) – Browser-based IRC client with permanent storage.
   1. [Jitsi](https://jitsi.org) - Multi-platform open-source video conferencing
   1. [Matrix](https://github.com/ResultadosDigitais/matrix) – Matrix is the online open-source workplace for distributed teams.


### PR DESCRIPTION
## 💬 New Communication Tool Addition

**HeyRobyn** is a native macOS unified inbox that brings email, Slack, and GitHub into a single window.

### Key Features:
- Native SwiftUI app (not Electron)
- Unified inbox for email, Slack, and GitHub
- Privacy-first, on-device data processing
- Built specifically for Mac users

### Why it fits here:
Remote teams often juggle multiple communication channels across email, Slack, and GitHub. HeyRobyn helps solve this fragmentation by consolidating these channels into one native Mac application, making it easier for distributed teams to stay on top of their communication.

### Links:
- Website: https://heyrobyn.ai
- Category: Tools > Communication

Thanks for maintaining this awesome list! 🙏