### PR TITLE
Add VerdeDesk to Law & Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 ## Law & Finance
   1. [1099 contractors](https://www.smartcapitalmind.com/what-is-a-1099-contractor.htm) – US based companies can hire remote workers as.
   1. [Transferwise](https://wise.com/gb/business/payouts) - Easy way to pay remote employees.
+  1. [VerdeDesk](https://verdedesk.vercel.app/) - Issue Portuguese green receipts (recibos verdes) and manage freelancer tax compliance in Portugal — in plain English. Built for D8 visa holders and expat freelancers.
 
 ## Others
   1. [awesome-digital-nomads](https://github.com/cbovis/awesome-digital-nomads) - 🏝 A curated list of awesome resources for Digital Nomads.


### PR DESCRIPTION
[VerdeDesk](https://verdedesk.vercel.app) helps remote workers and freelancers in Portugal manage their tax compliance in English.

Portugal is one of the top destinations for remote workers (9,000+ D8 digital nomad visas issued), but the government tax portal is entirely in Portuguese. VerdeDesk provides an English-language interface for issuing green receipts (recibos verdes), tracking income, and meeting tax deadlines.

Added to the **Law & Finance** section.