### PR TITLE
Add JobsByCulture to Job boards section

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [JOBBOX.io](https://landing.jobs/jobs) – Filter -> Remote only.
   1. [JobsCollider](https://jobscollider.com/remote-jobs) - * Tens of thousands of remote jobs from over 10,000 companies and startups worldwide. *
   1. [Jobspresso](https://jobspresso.co/) * High-quality remote positions that are open and legitimate *
+  1. [JobsByCulture](https://jobsbyculture.com/) - Culture-first AI & tech job board with remote-friendly filters, Glassdoor ratings, and culture values for 45+ companies.
   1. [JustRemote](https://justremote.co)
   1. [Larajobs](https://larajobs.com/?location=&remote=1) – The artisan employment connection
   1. [No Fluff Jobs](https://nofluffjobs.com/pl/#criteria=remote) – Filter -> “*remote*”


### PR DESCRIPTION
Adds [JobsByCulture](https://jobsbyculture.com/) to the Job boards section.

JobsByCulture is a culture-first job board for AI & tech companies with a strong remote focus — you can filter 7,100+ jobs by culture values like remote-friendly, async communication, flexible hours, and flat hierarchy. It profiles 45+ companies with Glassdoor ratings, WLB scores, and real employee reviews.