### PR TITLE
Add AI Dev Jobs to Job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Why working from home is both awesome and horrible](https://theoatmeal.com/comics/working_home)
 
 ## Job boards
+  1. [AI Dev Jobs](https://aidevboard.com) - 5000+ AI/ML developer roles with salary data. Filter by remote, tags, salary. REST API for agents.
   1. [Real Work From Anywhere](https://www.realworkfromanywhere.com/) - A site for fully location independent jobs. All jobs on the site are 100% work from anywhere.
   1. [4 Day Week](https://4dayweek.io) - Software jobs with a better work / life balance.
   1. [Authentic Jobs](https://authenticjobs.com/?search_location=remote)


### PR DESCRIPTION
Adding [AI Dev Jobs](https://aidevboard.com) to the Job boards section.

- 5,000+ AI/ML developer roles, filterable by remote/hybrid/onsite
- 1,381 remote roles currently listed
- Salary data on 2,100+ listings
- REST API for programmatic access
- Companies include Anthropic, OpenAI, DeepMind, Cohere, and 250+ more