### PR TITLE
Add AI Dev Jobs to Job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 ## Job boards
   1. [Real Work From Anywhere](https://www.realworkfromanywhere.com/) - A site for fully location independent jobs. All jobs on the site are 100% work from anywhere.
   1. [4 Day Week](https://4dayweek.io) - Software jobs with a better work / life balance.
+  1. [AI Dev Jobs](https://aidevboard.com) - AI/ML developer job board with 6,400+ positions, salary data, REST API, and MCP server.
   1. [Authentic Jobs](https://authenticjobs.com/?search_location=remote)
   1. [Built In](https://builtin.com/jobs/remote)
   1. [ClojureJobboard.com](https://clojurejobboard.com/remote-clojure-jobs.html)- Clojure jobs, filter -> Remote only


### PR DESCRIPTION
Adds [AI Dev Jobs](https://aidevboard.com) to the Job boards section in alphabetical order.

**AI Dev Jobs** is a job board focused on AI and machine learning developer positions. It aggregates 6,400+ roles from 370+ companies and offers programmatic access via a REST API and MCP server, making it useful for both human job seekers and AI-powered job search agents.

- Site: https://aidevboard.com
- Remote jobs: https://aidevboard.com/remote
- API: https://aidevboard.com/api/v1