### PR TITLE
Add web3vacancy to Job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Virtual Vocations](https://www.virtualvocations.com/)
   1. [Vue.js Jobs](https://vuejobs.com/) Find Vue.js jobs all around the world - Click on "Remote" tab.
   1. [Web3Jobs](https://web3.career/remote-jobs) - Remote Web3 Jobs
+  1. [web3vacancy](https://web3vacancy.com) - #1 Crypto & Web3 Job Board. Where crypto teams hire. Where builders get found.
   1. [Wellfound](https://wellfound.com/jobs) - Startup Jobs. Search by going to Job Type, and selecting "Remote OK".
   1. [We Work Remotely](https://weworkremotely.com/)
   1. [Workana](https://www.workana.com/) Freelance Job Board in Spanish and Portuguese


### PR DESCRIPTION
Adds [web3vacancy](https://web3vacancy.com) to the Job boards section — a crypto & Web3 job board in the same category as the Web3Jobs / Crypto Jobs / Cryptocurrency Jobs entries already listed.

Followed the existing one-line format and placed alphabetically after Web3Jobs.

Thanks for maintaining this list!