### PR TITLE
Add AI Dev Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 ## Job boards
   1. [Real Work From Anywhere](https://www.realworkfromanywhere.com/) - A site for fully location independent jobs. All jobs on the site are 100% work from anywhere.
   1. [4 Day Week](https://4dayweek.io) - Software jobs with a better work / life balance.
+  1. [AI Dev Jobs](https://aidevboard.com) - AI/ML jobs with REST API and MCP server for agents. Filter by remote, salary, tags.
   1. [Authentic Jobs](https://authenticjobs.com/?search_location=remote)
   1. [Built In](https://builtin.com/jobs/remote)
   1. [ClojureJobboard.com](https://clojurejobboard.com/remote-clojure-jobs.html)- Clojure jobs, filter -> Remote only


### PR DESCRIPTION
Adds [AI Dev Jobs](https://aidevboard.com) to the Job boards section (alphabetically placed).

**Why it's different from existing boards:**

- **AI/ML-specific focus** — exclusively indexes AI, ML, and data science positions from 370+ companies (OpenAI, Anthropic, Google DeepMind, etc.), unlike general-purpose boards
- **API-first** — offers a free REST API and MCP server so developers and AI agents can programmatically search and filter jobs. No other board in this list provides machine-readable access for agents
- **No paywall, no login required** — all jobs browsable and searchable immediately

The board has 6,400+ active listings and has been live for 6+ months.