### PR TITLE
Add AI Dev Jobs to Job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 ## Job boards
   1. [Real Work From Anywhere](https://www.realworkfromanywhere.com/) - A site for fully location independent jobs. All jobs on the site are 100% work from anywhere.
   1. [4 Day Week](https://4dayweek.io) - Software jobs with a better work / life balance.
+  1. [AI Dev Jobs](https://aidevboard.com) - AI/ML developer jobs with REST API and MCP server for agent-powered job search. 7,400+ positions from 417 companies.
   1. [Authentic Jobs](https://authenticjobs.com/?search_location=remote)
   1. [Built In](https://builtin.com/jobs/remote)
   1. [ClojureJobboard.com](https://clojurejobboard.com/remote-clojure-jobs.html)- Clojure jobs, filter -> Remote only


### PR DESCRIPTION
Adds [AI Dev Jobs](https://aidevboard.com) to the Job boards section in alphabetical order.

AI Dev Jobs is an AI/ML-focused job board with 7,400+ positions from 417 companies. It includes a REST API and MCP server, making it uniquely useful for developers building agent-powered job search tools. Many listed positions are remote-friendly.