### PR TITLE
Add AI Dev Jobs to Job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 ## Job boards
   1. [Real Work From Anywhere](https://www.realworkfromanywhere.com/) - A site for fully location independent jobs. All jobs on the site are 100% work from anywhere.
   1. [4 Day Week](https://4dayweek.io) - Software jobs with a better work / life balance.
+  1. [AI Dev Jobs](https://aidevboard.com) - 8,400+ AI/ML engineering roles from 489 AI-first companies, updated daily. Filter by remote/hybrid/onsite, seniority, and salary. Public REST API + MCP server for agent-driven job search.
   1. [Authentic Jobs](https://authenticjobs.com/?search_location=remote)
   1. [Built In](https://builtin.com/jobs/remote)
   1. [ClojureJobboard.com](https://clojurejobboard.com/remote-clojure-jobs.html)- Clojure jobs, filter -> Remote only


### PR DESCRIPTION
Adds [AI Dev Jobs](https://aidevboard.com) to the Job boards section, alphabetically between Authentic Jobs and Built In.

- 8,400+ AI/ML engineering roles from 489 AI-first companies, updated daily
- Filter by remote / hybrid / onsite, seniority, and salary
- Differentiated from the existing AI entries (Remote AI Jobs, Dataaxy) by: (a) explicit MCP server surface for AI agents to search jobs programmatically, and (b) 489-company AI-first curation (not a general aggregator).
- Public REST API at https://aidevboard.com/api/v1/jobs — free, no auth for 100 req/hr.

Remote share of the index: roughly half of all listings tag as fully remote or hybrid. Happy to adjust the entry if the positioning or alphabetical placement could be tighter.