### PR TITLE
Add FastTool to Tools / Others

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Qbserve](https://qotoqot.com/qbserve/) - Time tracking automation: freelance project tracking, timesheets, invoicing & real-time productivity feedback (Mac).
   1. [Miro](https://miro.com) (fka Realtime Board) - Distributed permanent virtual whiteboard.
   1. [Timing](https://timingapp.com/?lang=en) - Automatic time and productivity tracking for Mac. Helps you stay on track with your work (especially important when working remotely). Also ensures that no billable hours get lost if you are billing hourly (Mac).
+  1. [FastTool](https://fasttool.app) - 800+ browser-based productivity utilities (JSON formatter, regex tester, color tools, time zone converter, meeting cost calculator). No signup, works offline after first visit — handy when working across different networks.
 
 ## Law & Finance
   1. [1099 contractors](https://www.smartcapitalmind.com/what-is-a-1099-contractor.htm) – US based companies can hire remote workers as.


### PR DESCRIPTION
## Summary

Adds **FastTool** to **Tools → Others**.

- URL: https://fasttool.app
- What it offers: 800+ browser-based utilities incl. JSON formatter, regex tester, color tools, time zone converter, meeting cost calculator
- No signup, works offline after first visit (PWA)
- Privacy: fully client-side — inputs never leave the browser

## Line added

```
  1. [FastTool](https://fasttool.app) - 800+ browser-based productivity utilities (JSON formatter, regex tester, color tools, time zone converter, meeting cost calculator). No signup, works offline after first visit — handy when working across different networks.
```

Format matches the existing `Others` subsection entries (numbered markdown, link first, em-dash description). Happy to revise placement or wording.