### PR TITLE
Add usdevjobs.com to Job board

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Stream Native Jobs](https://streamnative.io/careers) - Scroll down to `Join Us`
   1. [SwissDev Jobs](https://swissdevjobs.ch/) - Filter -> "Remote / Work from home"
   1. [Upwork](https://www.upwork.com) - Find remote jobs in any category
+  1. [usdevjobs.com](https://usdevjobs.com/) - Real-time job aggregator for software, AI, data, engineers in US.
   1. [Virtual Vocations](https://www.virtualvocations.com/)
   1. [Vue.js Jobs](https://vuejobs.com/) Find Vue.js jobs all around the world - Click on "Remote" tab.
   1. [Web3Jobs](https://web3.career/remote-jobs) - Remote Web3 Jobs
@@ -206,6 +207,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [SlashJobs](https://slashjobs.com/) - Remote dev jobs aggregator. `and`/`or`/`not` filters, location search, fast, no sign-up/login.
   1. [tokenjobs.io](https://tokenjobs.io?remote=true) A web3 job aggregator where jobs can be filtered based on keywords, locations, languages and contract types. Anyone can publish a job offer.
   1. [UN Talent](https://untalent.org/jobs/home-based) - Vacancies at the United Nations and its agencies.
+  1. [usdevjobs.com](https://usdevjobs.com/) - Real-time job aggregator for software, AI, data, engineers in US.
   1. [Vollna](https://www.vollna.com/) - An aggregator for top freelance sites.
   1. [whoishiring.io](https://whoishiring.io/#!/search/19.41/-43.14/2/?remote=true)
 


### PR DESCRIPTION
Please Adds [US Dev Jobs](https://usdevjobs.com/) to the Job boards section.

- 1,000+ Software, AI/ML, Data engineering roles from US startups daily.
- The job list is updated hourly.
- Filter by remote , title, url, company.
- Aggregated only US jobs from Linkedin, Indeed, recruiting/staffing agencies.

Thank you for maintaining this list!