### PR TITLE
Add Gridnaut Recruiting to Job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Findjobit](https://findjobit.com/jobs) - Remote jobs for LATAM IT professionals.
   1. [freelancermap](https://www.freelancermap.com/projects/remote.html) - Freelance & contract jobs for IT experts (mostly German projects)
   1. [Golangprojects](https://www.golangprojects.com/golang-remote-jobs.html) filter -> Remote only
+  1. [Gridnaut Recruiting](https://gridnaut.site/jobs/) - Remote contract roles in AI training, evaluation, and domain-expert work, curated from Mercor referrals.
   1. [Guru](https://www.guru.com/) - (has MANY different categories outside software)
   1. [HackerX](https://hackerx.org/jobs/)
   1. [Hasjob](https://hasjob.co/) – Location filter -> "*Anywhere/Remote*"


### PR DESCRIPTION
Adding [Gridnaut Recruiting](https://gridnaut.site/jobs/) — a remote-only board listing AI training, evaluation, and domain-expert contract roles curated from Mercor.

- 100% remote
- Hourly contractor positions ($23–$180/hr range)
- ~73 active listings, refreshed weekly
- JobPosting structured data validates against Google for Jobs

Inserted alphabetically in the Job boards section between Golangprojects and Guru.