### PR TITLE
Add Job4Travelers

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [HigherEdJobs](https://www.higheredjobs.com/search/remote.cfm) has remote type filter.
   1. [HN hiring](https://www.hnhiring.me/) – Filter REMOTE.
   1. [Human Pages](https://humanpages.ai) - AI agents hire humans for real-world tasks.
+  1. [Job4Travelers](https://job4travelers.com/) - Remote jobs for digital nomads. Customer support, hospitality, content, tech, sales.
   1. [JOBBOX.io](https://landing.jobs/jobs) – Filter -> Remote only.
   1. [JobsCollider](https://jobscollider.com/remote-jobs) - * Tens of thousands of remote jobs from over 10,000 companies and startups worldwide. *
   1. [Jobspresso](https://jobspresso.co/) * High-quality remote positions that are open and legitimate *


### PR DESCRIPTION
## What

Adds [Job4Travelers](https://job4travelers.com/) under `## Job boards`, inserted alphabetically between *Human Pages* and *JOBBOX.io*.

```
1. [Job4Travelers](https://job4travelers.com/) - Remote jobs for digital nomads. Customer support, hospitality, content, tech, sales.
```

Name + description = 95 characters (under the 100-char rule).

## Why this is different from the existing entries (per CONTRIBUTING rule 1)

The existing job boards on the list skew heavily toward **tech/developer roles** (4 Day Week, AI Dev Jobs, Authentic Jobs, Built In, ClojureJobboard, Crypto Jobs, Drupal Jobs, Golangprojects, Larajobs, PyJobs, Ruby On Remote, TypeScriptJobs, etc.) or are **generic aggregators** (JobsCollider, Jobspresso, Remotive, JustRemote, Virtual Vocations).

Job4Travelers is positioned specifically for **digital nomads and travelers** — non-tech remote categories that suit a location-independent lifestyle: customer support, hospitality, content/writing, sales, and travel-adjacent roles. There is no existing entry on the list with this travel-first remote-DNA positioning.

## Remote DNA + content

- Live since 2024 with active job listings updated regularly
- Multiple role categories beyond tech (customer support, hospitality, content, sales)
- Editorial blog content covering remote work for travelers, digital nomad logistics, and visa/legal aspects

## Checklist

- [x] Link works and points to the correct location
- [x] Alphabetical placement (between *Human Pages* and *JOBBOX.io*)
- [x] Format matches: `[Name](link) - Description.`
- [x] Name + description under 100 characters
- [x] Greppable description (no vague marketing language)
- [x] Single suggestion in this PR
- [x] No trailing whitespace
- [x] Commit message follows convention (`Add Job4Travelers`)