### PR TITLE
Add ReloMap — free relocation comparison tool for remote workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Remote Shoals](https://remoteshoals.com/) - Work remotely? Get $10,000 to do your job from the Shoals.
   1. [Visto](https://visto.ai/) - We relocate developers to canada and help companies to bring developers outside the world!
   1. [Where Do I Move To](https://wheredoimoveto.com) - Get personalized city and country relocation recommendations based on 50+ factors.
+  1. [ReloMap](https://relomap.app) - Free cost of living comparison for 208 cities with verified data, tax calculator, and visa guides for remote workers.
 
 ## Interviewing
   1. [andreis/interview](https://github.com/Olshansk/interview) - Everything you need to kick ass on your coding interview


### PR DESCRIPTION
Adds [ReloMap](https://relomap.app) to the Relocation Incentives section.

ReloMap is a free platform that compares cost of living, taxes, visas, and safety across 208 cities — built specifically for remote workers evaluating where to relocate.

- Verified data from Numbeo, Expatistan, and official sources
- Tax calculator comparing special regimes (Portugal NHR, Spain Beckham Law, UAE 0%)
- Digital nomad visa requirements for every country
- Free, no signup required