### PR TITLE
Add TimezonePair

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,6 +605,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Timing](https://timingapp.com/?lang=en) - Automatic time and productivity tracking for Mac. Helps you stay on track with your work (especially important when working remotely). Also ensures that no billable hours get lost if you are billing hourly (Mac).
   1. [SYNCDATE](https://syncdate.app) - Automatically syncs events across multiple Google Calendar accounts — great for remote workers juggling work and personal schedules.
   1. [FastTool](https://fasttool.app) - 800+ browser-based productivity utilities (JSON formatter, regex tester, color tools, time zone converter, meeting cost calculator). No signup, works offline after first visit — handy when working across different networks.
+  1. [TimezonePair](https://www.timezonepair.com) — Live clocks and business-hours overlap for any two cities. One-click .ics calendar invite, shareable URL, DST-aware, no sign-up.
 
 ## Law & Finance
   1. [1099 contractors](https://www.smartcapitalmind.com/what-is-a-1099-contractor.htm) – US based companies can hire remote workers as.


### PR DESCRIPTION
<!-- Thanks for adding a resource about remote work to this list! 🎉

Add the URL below -->

https://www.timezonepair.com



<!-- And then, explain what this URL adds and why it is awesome -->
TimezonePair is a free web utility for distributed teams, remote workers, and anyone scheduling meetings across time zones. Pick any two of 300 cities to see live clocks, a 24-hour business-hours overlap band, and a one-click .ics calendar invite that imports into Google Calendar, Outlook, and Apple Calendar. A shareable URL round-trips the full meeting state so the other side sees the same view. DST-aware, no sign-up, no tracking. Built for remote-first teams who need to find when two cities can actually meet.


<!-- Make sure your pull request follows the [Contribution Guidelines](CONTRIBUTING.md) before submitting! Thank you. -->
