### PR TITLE
Add PredictionJobs to Job boards section

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Why working from home is both awesome and horrible](https://theoatmeal.com/comics/working_home)
 
 ## Job boards
+  1. [PredictionJobs](https://predictionjobs.co) — Job board for the prediction market space, featuring roles at Polymarket, Kalshi etc. Remote roles available. 
   1. [Real Jobs From Anywhere](https://realjobsfromanywhere.com/) - Curated remote job board featuring verified remote-first positions across various tech and non-tech roles.
   1. [Real Work From Anywhere](https://www.realworkfromanywhere.com/) - A site for fully location independent jobs. All jobs on the site are 100% work from anywhere.
   1. [4 Day Week](https://4dayweek.io) - Software jobs with a better work / life balance.


### PR DESCRIPTION
Adds PredictionJobs, a job board for the prediction market industry to job boards section. Roles from Polymarket, Kalshi etc. Remote roles also available. 

Happy to adjust placement or wording if needed.