### PR TITLE
Add career-ops to Interviewing

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Easyclimbtech](https://www.easyclimb.tech/) - $99 mock interviews with a FAANG mentor, also free P2P mock interviews
   1. [AI Interview Coach](https://em-tools.io/interview-prep) - Voice-based AI behavioral interview practice for engineering managers and software engineers. 130+ role-specific questions, STAR-format scoring, and 3 interviewer personas.
   1. [MianLing AI](https://mianlingai.com) - AI-powered real-time interview assistant that captures interviewer questions via system audio and generates professional answers in milliseconds
+  1. [career-ops](https://github.com/santifer/career-ops) - Open-source AI-powered job search system (Claude Code / OpenCode / Gemini CLI) with structured A-F job evaluation, interview prep via STAR+R story bank, ATS-optimized PDF generation, and portal scanners for Greenhouse/Ashby/Lever.
 ## Events
   1. [deceler8](https://sierraymar.exposure.co/decelerate-bali) - 10 days retreat
   1. [Project Getaway](https://www.projectgetaway.com/) - 30 days retreat


### PR DESCRIPTION
Adding **[career-ops](https://github.com/santifer/career-ops)** (46.5K ⭐ / MIT) to the **Interviewing** section.

### What it is

Open-source AI-powered job search system that runs locally with Claude Code (or OpenCode / Gemini CLI). Sits naturally next to entries like *AI Interview Coach* and *MianLing AI* in the same section — but is fully OSS, self-hosted, and goes beyond interview prep into the full evaluation pipeline.

### Features relevant to remote job hunters

- **Structured offer evaluation** — A-F scoring across 10 weighted dimensions before you even apply
- **Interview prep** — STAR+R story bank that accumulates 5-10 master stories across evaluations
- **ATS-optimized PDF generation** — keyword-injected resumes per JD
- **Portal scanners** — Greenhouse, Ashby, Lever, Wellfound (45+ companies pre-configured, including remote-first orgs)
- **Negotiation scripts** — salary, geographic discount pushback (relevant for remote hires), competing offer leverage
- **Batch processing** — evaluate 10+ offers in parallel
- **Pipeline dashboard** — terminal UI to browse, filter, and sort applications

### Social proof

- 46,511 stars / 9,725 forks
- README in 9 languages (EN/ES/DE/FR/PT-BR/KO/JA/ZH-CN/ZH-TW)
- Built and used by [@santifer](https://github.com/santifer) to evaluate 740+ remote offers and land a Head of Applied AI role
- MIT licensed — fully OSS