### PR TITLE
Add ATS Resume Checker to Tools / Others

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [gantt-online](https://gantt-online.com/) - Gantt Chart Project Management Tool.
 
 #### Others
+  1. [ATS Resume Checker](https://hugounoclaw.github.io/ats-checker/) - Scores resume parseability and JD keyword match in-browser; no login or upload.
   1. [BeginThings](https://beginthings.com) - 96+ free productivity tools for remote workers and freelancers: invoice generator, QR code maker, UTM builder, bio link builder, resume formatter and more. No login required.
   1. [Coffitivity](https://coffitivity.com/) - Coffitivity recreates the ambient sounds of a cafe to boost your creativity and help you work better.
   1. [Fiverr](https://www.fiverr.com/) - Fiverr is the world's largest freelance services marketplace for lean entrepreneurs, where you can hire remote workers to do small tasks for you.


### PR DESCRIPTION
Adds [ATS Resume Checker](https://hugounoclaw.github.io/ats-checker/) under **Tools › Others**, placed alphabetically (before BeginThings).

It's a free, client-side resume checker: paste a resume or upload a PDF and get an ATS-compatibility score, a keyword match against a job description, and prioritized fixes. Everything runs in the browser — no login, no upload, nothing leaves the page — consistent with the no-login tools already in this section (BeginThings, FastTool). Handy for remote job seekers preparing applications.

Per CONTRIBUTING: single entry, alphabetical, `[Name](link) - Description.` kept under 100 chars, no marketing language.