### PR TITLE
Add RemoteHunt.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Remote Index](https://remoteindex.co/) - Job board and aggregator for remote jobs in tech.
   1. [Remote OK](https://remoteok.com/) - Scrapes many job board feeds for remote positions.
   1. [Remote Python](https://www.remotepython.com/) - Job board and aggregator specifically for remote Python jobs.
+  1. [RemoteHunt](https://remotehunt.app/) - Aggregator that scores each remote job 0-100 against your resume. Tech, login.
   1. [SlashJobs](https://slashjobs.com/) - Remote dev jobs aggregator. `and`/`or`/`not` filters, location search, fast, no sign-up/login.
   1. [tokenjobs.io](https://tokenjobs.io?remote=true) A web3 job aggregator where jobs can be filtered based on keywords, locations, languages and contract types. Anyone can publish a job offer.
   1. [UN Talent](https://untalent.org/jobs/home-based) - Vacancies at the United Nations and its agencies.


### PR DESCRIPTION
Adds RemoteHunt to **Job boards aggregators**.

**Why it's different from the others here:** RemoteHunt aggregates verified remote jobs and scores each one 0-100 against the user's own resume, so you get a ranked shortlist of matches rather than a raw feed. None of the current aggregators score against your resume.

- Link works, points to the homepage.
- Placed among the Remote* entries.
- Objective wording; notes it requires login and focuses on tech roles.
