### PR TITLE
Add warpjobs (GPU/CUDA and ML-systems job board) to Job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [UI/UX Jobs Board](https://uiuxjobsboard.com/design-jobs/remote) - Remote jobs for UI/UX designers
   1. [EmbeddedJobs](https://embedded.jobs) — Remote job board dedicated to embedded systems engineers and developers.
   1. [Jobo](https://jobo.pl) - 100% remote-only verified jobs from Poland in IT, marketing, sales & more.
+  1. [warpjobs](https://warpjobs.com) - GPU/CUDA & ML-systems engineering roles from AI-infra companies; remote filter; daily.
   
 
 


### PR DESCRIPTION
Adds **warpjobs** (https://warpjobs.com) to the Job boards section.

**How it differs from the AI boards already listed** (AI Dev Jobs, Remote AI Jobs): those are broad "AI jobs" boards spanning ML / data / research / PM / generalist roles. warpjobs is deliberately narrow - only **GPU-kernel / CUDA / ML-systems / inference / performance-engineering** roles, aggregated daily from AI-infra companies' public ATS feeds (Greenhouse / Lever / Ashby).

- Free, no login, no paywall.
- Includes remote roles (filter region to Remote).
- Open-source scraper + RSS (`/feed.xml`) and JSON (`/jobs.json`) feeds.
- ~115 live roles from 23 companies, refreshed daily via CI.

Placed at the end of the Job boards section to match the most recent additions - happy to move it to strict alphabetical if you prefer.
