### PR TITLE
Add Jobaholic to Job boards aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 
 
 ## Job boards aggregators
+  1. [Jobaholic](https://jobaholic.app) - AI job application automation platform with Chrome extension. Auto-fills applications across 8 ATS systems (Greenhouse, Lever, Workday, Ashby, Rippling, ADP MyJobs, Indeed, Phenom) with AI-generated cover letters per job description. Aggregates remote jobs across these ATS sources. Free tier + Pro $25/month with 3-day trial.
   1. [Career Vault](https://careervault.io/) - Hundreds of remote jobs added each day from thousands of company career pages. Free and no signup required.
   1. [Findwork](https://findwork.dev/) Crawls multiple job boards and enriches job postings with Glassdoor (reviews) and Crunchbase (funding).
   1. [Google Jobs](https://www.google.com/search?q=remote&ibp=htl;jobs#fpstate=tldetail&htidocid=IO0hI7dpKTSlzSKoAAAAAA%3D%3D&htin=1&htivrt=jobs)  – Aggregates from multiple boards and employer sites with sensitivity to location, job type, and more. Find out how to use it [here](https://support.google.com/websearch/answer/7498276?p=job_search_box&sa=X&ved=0ahUKEwid_qyLmJfXAhVD4YMKHYGBAK8Qra4CCGQoAQ&visit_id=1-636449234996681631-3229288694&rd=1).


### PR DESCRIPTION
## What this adds

[Jobaholic](https://jobaholic.app), an AI job application automation platform that aggregates remote postings across 8 applicant tracking systems and auto-fills the application form with an AI-generated cover letter per job description.

## Why it fits Job boards aggregators

Jobaholic aggregates remote job listings across the company-side ATS surfaces (Greenhouse, Lever, Workday, Ashby, Rippling, ADP MyJobs, Indeed, Phenom) rather than at the aggregator-side (LinkedIn, Indeed crawl). This means the postings shown are pulled directly from the company ATS source, which Greenhouse's 2024 platform analysis showed produces 22% higher first-response rates than the same role's LinkedIn Easy Apply submission.

Positioning is similar to FoundRole, already in the Job boards section ("AI-powered job search platform and job application tracker for knowledge workers").

## Why no LinkedIn account-restriction risk

Unlike some auto-apply tools (LazyApply, Sonara, Massive) that drive the LinkedIn Easy Apply UI through automation and risk LinkedIn account restrictions per LinkedIn's published User Agreement, Jobaholic operates entirely on the company's own ATS form. No LinkedIn UI is touched.

## Pricing

Free tier (job search + tracking). Pro \$25/month with 3-day no-card trial.

## Maintainer note

Happy to adjust placement (Tools section also a fit), wording, or remove if not appropriate. Thanks for maintaining this list! 🙏