### PR TITLE
Add Company RemotePilot.dev

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -167,6 +167,7 @@ Una lista curada de excelentes recursos sobre [trabajo remoto](https://en.wikipe
   1. [remote-jobs](https://github.com/remoteintech/remote-jobs) - Una lista de empresas tech parcialmente o totalmente favorables al trabajo remoto
   1. [Remotees](https://weworkremotely.com/?utm_source=Remotees&utm_medium=Redirect&utm_campaign=Remotees)
   1. [RemoteJobs.lat](https://remotejobs.lat/) - Empleos remotos para gente de LATAM
+  1. [RemotePilot](https://remotepilot.dev) - Empleos remotos de desarrollo e ingeniería en empresas nativas de IA.
   1. [Remotive Jobs](https://remotive.com/)
   1. [Remote Works](https://remote.works-hub.com) - Empleos remotos en desarrollo de software
   1. [Ruby On Remote](https://rubyonremote.com/) - Todos los empleos remotos de Ruby en un solo lugar

--- a/README.fr.md
+++ b/README.fr.md
@@ -167,6 +167,7 @@ Une liste organisée de super ressources sur le [travail à distance](https://en
   1. [remote-jobs](https://github.com/remoteintech/remote-jobs) - Une liste d'entreprises tech favorables au remote, de façon partielle à complète
   1. [Remotees](https://weworkremotely.com/?utm_source=Remotees&utm_medium=Redirect&utm_campaign=Remotees)
   1. [RemoteJobs.lat](https://remotejobs.lat/) - Emplois à distance pour les personnes d'Amérique latine
+  1. [RemotePilot](https://remotepilot.dev) - Emplois de développement et d'ingénierie remote dans des entreprises natives de l'IA.
   1. [Remotive Jobs](https://remotive.com/)
   1. [Remote Works](https://remote.works-hub.com) - Emplois à distance dans le développement logiciel
   1. [Ruby On Remote](https://rubyonremote.com/) - Tous les emplois Ruby en remote au même endroit

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [remote-jobs](https://github.com/remoteintech/remote-jobs) - A list of semi to fully remote-friendly companies in tech
   1. [Remotees](https://weworkremotely.com/?utm_source=Remotees&utm_medium=Redirect&utm_campaign=Remotees)
   1. [RemoteJobs.lat](https://remotejobs.lat/) -  Remote jobs for LATAM people
+  1. [RemotePilot](https://remotepilot.dev) - Hand-curated remote developer and engineering jobs at AI-native companies.
   1. [Remotive Jobs](https://remotive.com/)
   1. [Remote Works](https://remote.works-hub.com) - Remote jobs in software development
   1. [Ruby On Remote](https://rubyonremote.com/) - All ruby remote jobs in one place

--- a/README.zh.md
+++ b/README.zh.md
@@ -175,6 +175,7 @@
   1. [remote-jobs](https://github.com/remoteintech/remote-jobs) - 一份科技行业从半远程友好到完全远程友好的公司列表
   1. [Remotees](https://weworkremotely.com/?utm_source=Remotees&utm_medium=Redirect&utm_campaign=Remotees)
   1. [RemoteJobs.lat](https://remotejobs.lat/) - 面向拉美人群的远程职位
+  1. [RemotePilot](https://remotepilot.dev) - AI原生公司精心挑选的远程开发和工程职位。
   1. [Remotive Jobs](https://remotive.com/)
   1. [Remote Works](https://remote.works-hub.com) - 软件开发领域的远程职位
   1. [Ruby On Remote](https://rubyonremote.com/) - 所有 Ruby 远程职位汇聚一处


### PR DESCRIPTION
<!-- Thanks for adding a resource about remote work to this list! 🎉

Add the URL below -->

https://remotepilot.dev

<!-- And then, explain what this URL adds and why it is awesome -->

RemotePilot is a hand-curated remote job board specifically dedicated to software engineering, developer, and technical roles at AI-native companies (e.g., LangChain, Cohere, Pinecone, Together AI, Mistral, and more). 

It is awesome and significantly different from other boards because:
1. **AI-First Focus:** Unlike generic remote job boards, it specifically aggregates positions from the rapidly growing ecosystem of AI-native organizations.
2. **High Quality & Open:** The site is completely free to search and apply, has no paywalls, does not require login or registration to view/apply to jobs, and contains direct apply links to the companies' career sites.
3. **Curated & Spam-free:** Roles are hand-verified to ensure they have genuine "remote DNA," avoiding the low-quality or hybrid/mislabeled listings often found on large aggregators.

<!-- Make sure your pull request follows the [Contribution Guidelines](CONTRIBUTING.md) before submitting! Thank you. -->