### PR TITLE
Add TimeZoneMeet to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,6 +605,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Timing](https://timingapp.com/?lang=en) - Automatic time and productivity tracking for Mac. Helps you stay on track with your work (especially important when working remotely). Also ensures that no billable hours get lost if you are billing hourly (Mac).
   1. [SYNCDATE](https://syncdate.app) - Automatically syncs events across multiple Google Calendar accounts — great for remote workers juggling work and personal schedules.
   1. [FastTool](https://fasttool.app) - 800+ browser-based productivity utilities (JSON formatter, regex tester, color tools, time zone converter, meeting cost calculator). No signup, works offline after first visit — handy when working across different networks.
+  1. [TimeZoneMeet](https://timezonemeet.app/) - Find fair meeting times across time zones and see a live world clock for your distributed team. Free, no signup, with an embeddable widget and a JSON API.
 
 ## Law & Finance
   1. [1099 contractors](https://www.smartcapitalmind.com/what-is-a-1099-contractor.htm) – US based companies can hire remote workers as.


### PR DESCRIPTION
Adds **TimeZoneMeet** to *Tools → Others* (alongside the existing time-zone/scheduling tools like FastTool and SYNCDATE).

> [TimeZoneMeet](https://timezonemeet.app/) - Find fair meeting times across time zones and see a live world clock for your distributed team. Free, no signup, with an embeddable widget and a JSON API.

Directly relevant to remote/distributed teams: it finds overlapping working-hour windows across cities and offers a free embeddable world-clock widget (and a free JSON API) for team dashboards. Free, no signup required. Format matches the section (numbered list, `[Name](url) - Description.`).