### PR TITLE
Add LLC Class to Law & Finance: Wyoming LLC registration for non-US remote workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,6 +611,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Your Tax Base](https://yourtaxbase.com/) - Florida residency and tax domicile services for digital nomads and remote workers, with virtual mailbox, Declaration of Domicile filing, and step-by-step guidance for establishing a tax-free home base.
   1. [Transferwise](https://wise.com/gb/business/payouts) - Easy way to pay remote employees.
   1. [VerdeDesk](https://verdedesk.vercel.app/) - Issue Portuguese green receipts (recibos verdes) and manage freelancer tax compliance in Portugal — in plain English. Built for D8 visa holders and expat freelancers.
+  1. [LLC Class](https://llcclass.com) - [Wyoming LLC registration](https://llcclass.com/wyoming) for remote workers and freelancers based outside the US; includes [registered agent for LLC](https://llcclass.com/what-is-llc-registered-agent), EIN, and Operating Agreement — enables access to Stripe, Mercury, and US business banking.
 
 ## Others
   1. [awesome-digital-nomads](https://github.com/cbovis/awesome-digital-nomads) - 🏝 A curated list of awesome resources for Digital Nomads.


### PR DESCRIPTION
## What this adds

Adds [LLC Class](https://llcclass.com) to the **Law & Finance** section for remote workers and freelancers who are based outside the US and need a US business entity.

A common pain point for non-US remote workers is getting paid via Stripe or opening a US bank account (Mercury, Relay) — both of which require a US company. LLC Class solves this with [Wyoming LLC registration](https://llcclass.com/wyoming) that includes:

- [Registered agent for LLC](https://llcclass.com/what-is-llc-registered-agent) (legally required in all states)
- EIN (US tax ID, required for banking and Stripe)
- Operating Agreement

Wyoming is the preferred state for non-US founders: no state income tax, strong asset protection, and low annual fees. After formation, remote workers can immediately apply for Stripe and Mercury bank accounts — unlocking the full US payment ecosystem.

This fills a practical gap in the Law & Finance section for the international remote workers this list serves.