### PR TITLE
Update README.md, add CEEhire to Job Boards section

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Authentic Jobs](https://authenticjobs.com/?search_location=remote)
   1. [Built In](https://builtin.com/jobs/remote)
   1. [Trabajo Remoto Chile](https://trabajoremotochile.com/) - Remote job board for Chilean professionals seeking work with US and European companies.
+  1. 1. [CEEhire](https://ceehire.com) - Validated remote IT jobs from US/UK companies for Central & Eastern European tech talent: transparent salaries, no ghost jobs.
   1. [ClojureJobboard.com](https://clojurejobboard.com/remote-clojure-jobs.html)- Clojure jobs, filter -> Remote only
   1. [Crypto Jobs](https://crypto.jobs/?jobs=remote) - Blockchain jobs for crypto enthusiasts.
   1. [Crypto Jobs List](https://cryptojobslist.com/remote) - #1 job board to find and post crypto, bitcoin and blockchain jobs.


### PR DESCRIPTION
CEEhire focuses on a completely underserved niche: connecting US/UK companies with verified remote IT talent from Central & Eastern Europe. All listings are recruiter-validated (no ghost jobs), salaries are transparent. No similar board is listed for the CEE region.

<!-- Thanks for adding a resource about remote work to this list! 🎉

Add the URL below -->
https://ceehire.com



<!-- And then, explain what this URL adds and why it is awesome -->
CEEhire is a niche remote IT job board connecting US/UK companies with recruiter-validated tech talent from Central & Eastern Europe. Transparent salaries, no ghost jobs. Unique focus on the CEE region with no equivalent listed here.


<!-- Make sure your pull request follows the [Contribution Guidelines](CONTRIBUTING.md) before submitting! Thank you. -->
