### PR TITLE
Add SOLID.Jobs a polish job board to the list of job boards

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -172,6 +172,7 @@ Una lista curada de excelentes recursos sobre [trabajo remoto](https://en.wikipe
   1. [Ruby On Remote](https://rubyonremote.com/) - Todos los empleos remotos de Ruby en un solo lugar
   1. [Skip the Drive](https://www.skipthedrive.com/)
   1. [Slasify](https://slasify.com/en) - Oportunidades remotas de tecnología, arte/diseño y marketing desde Asia, con servicio global de nómina incluido.
+  1. [SolidJobs](https://solid.jobs/) - Portal de empleo IT con filtro remoto, enfocado en rangos salariales transparentes.
   1. [Stream Native Jobs](https://streamnative.io/careers) - Desplázate hasta `Join Us`
   1. [SwissDev Jobs](https://swissdevjobs.ch/) - Filtro -> "Remote / Work from home"
   1. [Upwork](https://www.upwork.com) - Encuentra empleos remotos en cualquier categoría

--- a/README.fr.md
+++ b/README.fr.md
@@ -172,6 +172,7 @@ Une liste organisée de super ressources sur le [travail à distance](https://en
   1. [Ruby On Remote](https://rubyonremote.com/) - Tous les emplois Ruby en remote au même endroit
   1. [Skip the Drive](https://www.skipthedrive.com/)
   1. [Slasify](https://slasify.com/en) - Opportunités à distance dans la tech, l'art/design et le marketing depuis l'Asie, avec service de paie global inclus.
+  1. [SolidJobs](https://solid.jobs/) - Plateforme d'emploi IT avec filtre télétravail, axée sur des fourchettes de salaire transparentes.
   1. [Stream Native Jobs](https://streamnative.io/careers) - Faites défiler jusqu'à `Join Us`
   1. [SwissDev Jobs](https://swissdevjobs.ch/) - Filtre -> "Remote / Work from home"
   1. [Upwork](https://www.upwork.com) - Trouvez des emplois à distance dans n'importe quelle catégorie

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Ruby On Remote](https://rubyonremote.com/) - All ruby remote jobs in one place
   1. [Skip the Drive](https://www.skipthedrive.com/)
   1. [Slasify](https://slasify.com/en) - Remote tech, art/design and marketing opportunities from Asia, global payroll service included.
+  1. [SolidJobs](https://solid.jobs/) - IT job board with remote filter, focused on transparent salary ranges.
   1. [Stream Native Jobs](https://streamnative.io/careers) - Scroll down to `Join Us`
   1. [SwissDev Jobs](https://swissdevjobs.ch/) - Filter -> "Remote / Work from home"
   1. [TypeScriptJobs](https://typescriptjobs.net/) - TypeScript positions with remote filter

--- a/README.zh.md
+++ b/README.zh.md
@@ -180,6 +180,7 @@
   1. [Ruby On Remote](https://rubyonremote.com/) - 所有 Ruby 远程职位汇聚一处
   1. [Skip the Drive](https://www.skipthedrive.com/)
   1. [Slasify](https://slasify.com/en) - 来自亚洲的远程技术、艺术/设计和营销机会，包含全球薪资发放服务。
+  1. [SolidJobs](https://solid.jobs/) - IT 招聘网站，支持远程筛选，专注于透明的薪资范围。
   1. [Stream Native Jobs](https://streamnative.io/careers) - 向下滚动到 `Join Us`
   1. [SwissDev Jobs](https://swissdevjobs.ch/) - 筛选 -> "Remote / Work from home"
   1. [Upwork](https://www.upwork.com) - 在任意类别中寻找远程工作


### PR DESCRIPTION
https://solid.jobs/

SOLID.Jobs - is a polish job board focusing on job offers for Specialist mainly in IT field.
