### PR TITLE
Add Meridian to Job boards aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Findwork](https://findwork.dev/) Crawls multiple job boards and enriches job postings with Glassdoor (reviews) and Crunchbase (funding).
   1. [Google Jobs](https://www.google.com/search?q=remote&ibp=htl;jobs#fpstate=tldetail&htidocid=IO0hI7dpKTSlzSKoAAAAAA%3D%3D&htin=1&htivrt=jobs)  – Aggregates from multiple boards and employer sites with sensitivity to location, job type, and more. Find out how to use it [here](https://support.google.com/websearch/answer/7498276?p=job_search_box&sa=X&ved=0ahUKEwid_qyLmJfXAhVD4YMKHYGBAK8Qra4CCGQoAQ&visit_id=1-636449234996681631-3229288694&rd=1).
   1. [JS Remotely](https://javascript.jobs/remote) - All remote JavaScript jobs on one board
+  1. [Meridian](https://meridianremote.com/) - Remote tech jobs matched to your timezone across the US, LATAM, and EU. Aggregated from top job boards and ATS feeds, deduplicated, and always linking to the original posting.
   1. [Remote.io](https://www.remote.io/) - Job board and aggregator for remote jobs, primarily tech.
   1. [Remote 4 Me](https://remote4me.com/) - An aggregator for remote jobs in tech and non-tech.
   1. [Remote Index](https://remoteindex.co/) - Job board and aggregator for remote jobs in tech.


### PR DESCRIPTION
Adds [Meridian](https://meridianremote.com/) to the **Job boards aggregators** section (alphabetical placement).

Meridian aggregates remote tech jobs from top job boards and ATS feeds, deduplicates them, matches roles to your timezone (US, LATAM, EU), and always links to the original posting.