### PR TITLE
Add Acalcia (free no-signup money & tax calculators)

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,6 +611,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Your Tax Base](https://yourtaxbase.com/) - Florida residency and tax domicile services for digital nomads and remote workers, with virtual mailbox, Declaration of Domicile filing, and step-by-step guidance for establishing a tax-free home base.
   1. [Transferwise](https://wise.com/gb/business/payouts) - Easy way to pay remote employees.
   1. [VerdeDesk](https://verdedesk.vercel.app/) - Issue Portuguese green receipts (recibos verdes) and manage freelancer tax compliance in Portugal — in plain English. Built for D8 visa holders and expat freelancers.
+1. [Acalcia](https://acalcia.com) - Free, no-signup suite of 41 in-browser money and tax calculators for US freelancers, online sellers, and creators — self-employment and quarterly taxes, mileage, marketplace and processor fees (Etsy/eBay/Amazon FBA/Stripe/PayPal), freelance and project rates, pricing and margins, plus invoicing with a PDF invoice generator.
 
 ## Others
   1. [awesome-digital-nomads](https://github.com/cbovis/awesome-digital-nomads) - 🏝 A curated list of awesome resources for Digital Nomads.


### PR DESCRIPTION
Adds [Acalcia](https://acalcia.com) — a free, no-signup suite of in-browser money & tax calculators for freelancers, online sellers, and creators (self-employment & quarterly tax, marketplace/payment fees, freelance rates, pricing, invoicing).

- Follows this list's existing entry format
- Single addition, not a duplicate (searched the list)
- Static, privacy-friendly, runs entirely in the browser — no signup, no paywall

Disclosure: I'm the maker. Thanks for curating this list!