### PR TITLE
Add Elcano to Law & Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,6 +611,8 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Your Tax Base](https://yourtaxbase.com/) - Florida residency and tax domicile services for digital nomads and remote workers, with virtual mailbox, Declaration of Domicile filing, and step-by-step guidance for establishing a tax-free home base.
   1. [Transferwise](https://wise.com/gb/business/payouts) - Easy way to pay remote employees.
   1. [VerdeDesk](https://verdedesk.vercel.app/) - Issue Portuguese green receipts (recibos verdes) and manage freelancer tax compliance in Portugal — in plain English. Built for D8 visa holders and expat freelancers.
+  1. [Elcano](https://elcano.tax) - International tax-residency day tracker that flags 183-day, Schengen 90/180, UK SRT and US SPT thresholds and exports an audit-ready workpaper. Data stays local, free to start.
+
 
 ## Others
   1. [awesome-digital-nomads](https://github.com/cbovis/awesome-digital-nomads) - 🏝 A curated list of awesome resources for Digital Nomads.


### PR DESCRIPTION
Adds Elcano (https://elcano.tax) to Law & Finance — an international, privacy-first tax-residency day tracker for remote workers living between jurisdictions. Flags 183-day, Schengen 90/180, UK SRT and US SPT thresholds and exports an audit-ready workpaper (methodology, evidence index, gap analysis). Complements "Your Tax Base" and "VerdeDesk" already listed. Free to start, data stays local.

<!-- Thanks for adding a resource about remote work to this list! 🎉

Add the URL below -->



<!-- And then, explain what this URL adds and why it is awesome -->



<!-- Make sure your pull request follows the [Contribution Guidelines](CONTRIBUTING.md) before submitting! Thank you. -->
