### PR TITLE
Add Remote1stJobs to Job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [PyJobs.com](https://www.pyjobs.com/?remoteLevel[0]=1&remoteLevel[1]=2) - Jobs for Python developers
   1. [Remote Game Jobs](https://remotegamejobs.com/) - Find remote work and talent in the game industry.
   1. [Remote Job Assistant](https://remotejobassistant.com/) - Remote jobs for non-technical professionals, moms returning to work, and career changers.
+  2. [Remote1stJobs](https://www.remote1stjobs.com) - UK, Europe & EMEA remote-first jobs. Filters out US-only and fake-remote roles; direct employer ATS links (Greenhouse, Lever, Ashby), salary-visible, daily-fresh.
   1. [remote-es/remotes](https://github.com/remote-es/remotes) - Repository listing companies which offer full-time remote jobs with Spanish contracts
   1. [thatmlopsguy/remote-pt](https://github.com/thatmlopsguy/remote-pt) - Repository listing companies which offer full-time remote jobs with Portuguese contracts
   1. [remote-jobs](https://github.com/remoteintech/remote-jobs) - A list of semi to fully remote-friendly companies in tech


### PR DESCRIPTION
URL: https://www.remote1stjobs.com

Remote1stJobs is a UK/Europe/EMEA-focused remote jobs board. It scrapes directly from company ATS (Greenhouse, Lever, Ashby, Workable) for direct employer links, filters out US-only and recruiter-duplicate listings, and surfaces salary-visible roles. Fills the Europe-eligibility gap alongside SwissDev Jobs and zuhausejobs already listed in this section. Live since 2025 with 6+ months of continuously refreshed content.