### PR TITLE
Add freehire to Job boards aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 ## Job boards aggregators
   1. [Career Vault](https://careervault.io/) - Hundreds of remote jobs added each day from thousands of company career pages. Free and no signup required.
   1. [Findwork](https://findwork.dev/) Crawls multiple job boards and enriches job postings with Glassdoor (reviews) and Crunchbase (funding).
+  1. [freehire](https://freehire.dev/) - Open-source IT job aggregator: pulls from hundreds of company ATS boards plus public Telegram channels, then normalizes, de-duplicates and AI-enriches every posting. Faceted search by role, stack, region and remote mode. Free, no signup, self-hostable.
   1. [Google Jobs](https://www.google.com/search?q=remote&ibp=htl;jobs#fpstate=tldetail&htidocid=IO0hI7dpKTSlzSKoAAAAAA%3D%3D&htin=1&htivrt=jobs)  – Aggregates from multiple boards and employer sites with sensitivity to location, job type, and more. Find out how to use it [here](https://support.google.com/websearch/answer/7498276?p=job_search_box&sa=X&ved=0ahUKEwid_qyLmJfXAhVD4YMKHYGBAK8Qra4CCGQoAQ&visit_id=1-636449234996681631-3229288694&rd=1).
   1. [JS Remotely](https://javascript.jobs/remote) - All remote JavaScript jobs on one board
   1. [Remote.io](https://www.remote.io/) - Job board and aggregator for remote jobs, primarily tech.


### PR DESCRIPTION
Adds **[freehire](https://freehire.dev/)** to the *Job boards aggregators* section.

**What it is:** an open-source IT job aggregator that pulls postings directly from hundreds of company ATS boards (Greenhouse, Lever, Ashby, Workday, iCIMS, …) plus public Telegram channels, then normalizes them into one schema, de-duplicates the same role across sources, and AI-enriches each listing. Faceted search (role, stack, seniority, region, remote mode) with CV-based recommendations.

**Why it should be added / how it's different (per the contributing guidelines):**
- **Free, no paywall, no login required** to browse — meets the quality bar.
- **A true aggregator, not a single-company board** — it dedups the same posting across many sources, which is distinct from the individual boards in the list.
- **Open-source & self-hostable** (Go + Postgres + Meilisearch), unlike the closed aggregators already listed — [source](https://github.com/strelov1/freehire).
- **Live, freshly-crawled listings** with a real remote-mode filter, not a stale directory.

Placed alphabetically after Findwork. Thanks for maintaining this list!