### PR TITLE
Add Banking Access Index to Law & Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,6 +611,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Your Tax Base](https://yourtaxbase.com/) - Florida residency and tax domicile services for digital nomads and remote workers, with virtual mailbox, Declaration of Domicile filing, and step-by-step guidance for establishing a tax-free home base.
   1. [Transferwise](https://wise.com/gb/business/payouts) - Easy way to pay remote employees.
   1. [VerdeDesk](https://verdedesk.vercel.app/) - Issue Portuguese green receipts (recibos verdes) and manage freelancer tax compliance in Portugal — in plain English. Built for D8 visa holders and expat freelancers.
+  1. [Banking Access Index](https://www.globalsolo.global/data/banking-access-index) - Free CC-BY dataset of which US banking providers accept non-US-resident founders, by country — each claim verified against the provider's published policy, with CSV/JSON downloads.
 
 ## Others
   1. [awesome-digital-nomads](https://github.com/cbovis/awesome-digital-nomads) - 🏝 A curated list of awesome resources for Digital Nomads.


### PR DESCRIPTION
For remote founders and contractors outside the US who need a US business account: the Banking Access Index is a free CC-BY dataset of which 18 US banking providers accept non-US-resident founders, per country — each claim verified against the provider's published policy, with CSV/JSON downloads. A dataset, not a service.

Disclosure: I built and maintain this dataset.