### PR TITLE
Add daily-job-sweeper

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 
 ## Job boards aggregators
   1. [Career Vault](https://careervault.io/) - Hundreds of remote jobs added each day from thousands of company career pages. Free and no signup required.
+  1. [daily-job-sweeper](https://github.com/HenryCordes/daily-job-sweeper) - Self-hosted sweep of 20+ remote job boards, deduped and ranked. Node, MIT. 
   1. [Findwork](https://findwork.dev/) Crawls multiple job boards and enriches job postings with Glassdoor (reviews) and Crunchbase (funding).
   1. [Google Jobs](https://www.google.com/search?q=remote&ibp=htl;jobs#fpstate=tldetail&htidocid=IO0hI7dpKTSlzSKoAAAAAA%3D%3D&htin=1&htivrt=jobs)  – Aggregates from multiple boards and employer sites with sensitivity to location, job type, and more. Find out how to use it [here](https://support.google.com/websearch/answer/7498276?p=job_search_box&sa=X&ved=0ahUKEwid_qyLmJfXAhVD4YMKHYGBAK8Qra4CCGQoAQ&visit_id=1-636449234996681631-3229288694&rd=1).
   1. [JS Remotely](https://javascript.jobs/remote) - All remote JavaScript jobs on one board


### PR DESCRIPTION
Self-hosted, open-source alternative to the hosted aggregators here: it sweeps 20+ public job APIs and ATS boards locally, no login or paywall, dedupes across sources and ranks to your own profile. Different from existing entries because you run and tune it yourself.