### PR TITLE
Add RoamJobs to Job boards aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Remote Index](https://remoteindex.co/) - Job board and aggregator for remote jobs in tech.
   1. [Remote OK](https://remoteok.com/) - Scrapes many job board feeds for remote positions.
   1. [Remote Python](https://www.remotepython.com/) - Job board and aggregator specifically for remote Python jobs.
+  1. [RoamJobs](https://roamjobs.com/) - Guides comparing remote job boards by country and role, with remote-work visa and tax notes for 80+ countries.
   1. [SlashJobs](https://slashjobs.com/) - Remote dev jobs aggregator. `and`/`or`/`not` filters, location search, fast, no sign-up/login.
   1. [tokenjobs.io](https://tokenjobs.io?remote=true) A web3 job aggregator where jobs can be filtered based on keywords, locations, languages and contract types. Anyone can publish a job offer.
   1. [UN Talent](https://untalent.org/jobs/home-based) - Vacancies at the United Nations and its agencies.


### PR DESCRIPTION
Adds [RoamJobs](https://roamjobs.com/) to the **Job boards aggregators** section.

RoamJobs publishes free guides comparing remote job boards by country and role, plus remote-work visa and tax notes across 80+ countries. No signup required. It sits naturally alongside the other board-comparison/aggregator resources already in this section.

One line added, alphabetical placement (after Remote Python, before SlashJobs).