### PR TITLE
Add Remote PM Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [PyJobs.com](https://www.pyjobs.com/?remoteLevel[0]=1&remoteLevel[1]=2) - Jobs for Python developers
   1. [Remote Game Jobs](https://remotegamejobs.com/) - Find remote work and talent in the game industry.
   1. [Remote Job Assistant](https://remotejobassistant.com/) - Remote jobs for non-technical professionals, moms returning to work, and career changers.
+  1. [Remote PM Jobs](https://remotepmjobs.com/) - Remote-only PM jobs pulled from ATSs, verified remote, no ghost jobs.
   1. [remote-es/remotes](https://github.com/remote-es/remotes) - Repository listing companies which offer full-time remote jobs with Spanish contracts
   1. [thatmlopsguy/remote-pt](https://github.com/thatmlopsguy/remote-pt) - Repository listing companies which offer full-time remote jobs with Portuguese contracts
   1. [remote-jobs](https://github.com/remoteintech/remote-jobs) - A list of semi to fully remote-friendly companies in tech


### PR DESCRIPTION
https://remotepmjobs.com/

Remote PM Jobs is a free job board for remote-only product manager roles.

Differs from the general boards listed: PM-only, every listing scraped directly from the company's ATS and verified fully remote (no hybrid), closed roles removed daily, majority of listings include posted salary ranges, plus a free client-side resume matcher. No login or paywall.

Entry added alphabetically near the other "Remote X Jobs" listings in the Job boards section.