### PR TITLE
Add OnlyFrontendJobs to Job boards section

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Larajobs](https://larajobs.com/?location=&remote=1) – The artisan employment connection
   1. [No Fluff Jobs](https://nofluffjobs.com/pl/#criteria=remote) – Filter -> “*remote*”
   1. [NODESK](https://nodesk.co/remote-jobs/)
+  1. [OnlyFrontendJobs](https://www.onlyfrontendjobs.com) - Curated frontend jobs for React, Vue, Next.js, Angular and TypeScript developers.
   1. [Power to Fly](https://powertofly.com/jobs/) - Specific to women
   1. [Remote AI Jobs](https://www.moaijobs.com/remote-ai-jobs) - Remote AI jobs in Machine Learning, Engineering, Data Science, Research, etc
   1. [Remote Backend Jobs](https://www.remotebackendjobs.com/) - Find exclusively remote backend jobs aggregated from the top 22 job boards in the world.


### PR DESCRIPTION
### Description
Adds [OnlyFrontendJobs](https://onlyfrontendjobs.com) to the **Job boards** section.

**OnlyFrontendJobs** is a curated remote job board dedicated exclusively to frontend engineers (React, Vue, Next.js, Angular, Svelte, TypeScript) featuring verified compensation metrics.

- URL: https://onlyfrontendjobs.com
- Category: Job boards
- Relevant Roles: Remote Frontend, Full-stack UI, Web Engineering