### PR TITLE
Add Landed

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Jobspresso](https://jobspresso.co/) * High-quality remote positions that are open and legitimate *
   1. [JobsByCulture](https://jobsbyculture.com/) - Culture-first AI & tech job board with remote-friendly filters, Glassdoor ratings, and culture values for 45+ companies.
   1. [JustRemote](https://justremote.co)
+  1. [Landed](https://landed.jobs) - AI-native jobs with remote-eligibility filters, fit scores, and an MCP server. Free tier.
   1. [Larajobs](https://larajobs.com/?location=&remote=1) – The artisan employment connection
   1. [No Fluff Jobs](https://nofluffjobs.com/pl/#criteria=remote) – Filter -> “*remote*”
   1. [NODESK](https://nodesk.co/remote-jobs/)


### PR DESCRIPTION
Adds Landed to Job boards, inserted alphabetically between JustRemote and Larajobs.

**Why it is different from the others on the list**

1. **Remote eligibility is structured, not a text filter.** Most boards match the word "remote" in a title or description. Landed stores canonical remote-eligibility country and region codes separately from the physical office location, so you can filter for roles a person in a specific country can actually be hired into, rather than roles that merely say "remote" and then require US work authorization.

2. **It is queryable from an editor over MCP.** The public server at `https://mcp.landed.jobs/mcp` exposes `search_jobs`, `get_job_form`, and `get_learning_content`, so an agent in Claude Code, Cursor, or VS Code can search roles and pull a job's actual application form without opening a browser. No other board on this list has an MCP interface. Published on the Official MCP Registry as `io.github.landedjobs/landed`.

3. **Scope is AI-native roles specifically.** AI engineer, LLM engineer, applied scientist, forward deployed engineer, GTM engineer, and similar, rather than general tech listings.

No paywall and no login required to browse. Free tier for matching.

Checked against the guidelines: link verified working, entry sorted alphabetically, `[Name](link) - Description.` format, name plus description is 98 characters, no trailing whitespace, single suggestion in this PR, and searched existing entries for duplicates first.
