### PR TITLE
Add AI Applyd

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [gantt-online](https://gantt-online.com/) - Gantt Chart Project Management Tool.
 
 #### Others
+  1. [AI Applyd](https://aiapplyd.com) - Submits on the employer's ATS and reports the status it returns, including failures.
   1. [BeginThings](https://beginthings.com) - 96+ free productivity tools for remote workers and freelancers: invoice generator, QR code maker, UTM builder, bio link builder, resume formatter and more. No login required.
   1. [Coffitivity](https://coffitivity.com/) - Coffitivity recreates the ambient sounds of a cafe to boost your creativity and help you work better.
   1. [Fiverr](https://www.fiverr.com/) - Fiverr is the world's largest freelance services marketplace for lean entrepreneurs, where you can hire remote workers to do small tasks for you.


### PR DESCRIPTION
Added under **Tools > Others**, not under Job boards, because it is not a board and rule 1 rightly exists to keep those out.

**Why it is different from what is already listed:** the tools in this space stop at filling the form. This one drives the employer's own applicant tracking system, submits there, and then reads back the status that system returns, so a failed application is reported as failed rather than recorded as sent. Employer-side confirmation currently works on Greenhouse, Workday, Personio and Teamtailor.

Rule checks:
- Rule 11 format `[Name](link) - Description.`, name + description is 96 characters, under the 100 limit.
- Rule 12, no marketing adjectives; wording chosen for greppability (ATS, submits, status, failures).
- Rule 2, link is live and returns 200.
- Line endings preserved as CRLF, so the diff is a single inserted line.

Disclosure: I work on it. If a job-application tool is out of scope for a remote-work list, say so and I will close this myself, no hard feelings.