### PR TITLE
Add ChainJobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Authentic Jobs](https://authenticjobs.com/?search_location=remote)
   1. [Built In](https://builtin.com/jobs/remote)
   1. [Trabajo Remoto Chile](https://trabajoremotochile.com/) - Remote job board for Chilean professionals seeking work with US and European companies.
+  1. [ChainJobs](https://chainjobs.io/remote-crypto-jobs/) - Crypto/web3 remote jobs from official ATS boards only. Salary data, free, no login.
   1. [ClojureJobboard.com](https://clojurejobboard.com/remote-clojure-jobs.html)- Clojure jobs, filter -> Remote only
   1. [Crypto Jobs](https://crypto.jobs/?jobs=remote) - Blockchain jobs for crypto enthusiasts.
   1. [Crypto Jobs List](https://cryptojobslist.com/remote) - #1 job board to find and post crypto, bitcoin and blockchain jobs.


### PR DESCRIPTION
Adding **ChainJobs** to Job boards (alphabetical position, before ClojureJobboard).

Per guideline 1, why it's different from the crypto boards already listed:

- **Source model**: listings are aggregated exclusively from companies' own official ATS boards (Greenhouse / Lever / Ashby public APIs) and re-scraped daily — roles auto-expire when they close at the source, so there are no stale listings or reposts. The boards currently listed are primarily self-posted/paid-listing boards.
- **No paywall, no login** — every listing links straight to the employer's own application page.
- **Salary transparency**: 470+ roles carry employer-published USD bands, browsable with medians/percentiles at https://chainjobs.io/crypto-salaries/ (only employer-published figures — nothing estimated).
- **Non-technical emphasis**: marketing, BD, community and ops roles get equal billing with engineering — a gap among existing crypto boards.

Honest note on guideline 13: the site launched July 2026, so it is young — but it carries 2,650+ live listings across 120 companies today, refreshed daily, which is the content depth the guideline is after. Happy to close this and return later if you'd rather see more track record.

The linked page is the remote-only view (guideline 15: listing page, not a single post).
