### PR TITLE
Add Maneki to Job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [JobsByCulture](https://jobsbyculture.com/) - Culture-first AI & tech job board with remote-friendly filters, Glassdoor ratings, and culture values for 45+ companies.
   1. [JustRemote](https://justremote.co)
   1. [Larajobs](https://larajobs.com/?location=&remote=1) – The artisan employment connection
+  1. [Maneki](https://maneki.work/jobs/remote) - Web3 jobs aggregated nightly from 500+ companies' own career pages; remote filters, salary data, expired listings removed automatically.
   1. [No Fluff Jobs](https://nofluffjobs.com/pl/#criteria=remote) – Filter -> “*remote*”
   1. [NODESK](https://nodesk.co/remote-jobs/)
   1. [Power to Fly](https://powertofly.com/jobs/) - Specific to women


### PR DESCRIPTION
Adding [Maneki](https://maneki.work/jobs/remote) to the Job boards section (alphabetical position, section format followed).

Disclosure: I built it.

- Aggregates web3/crypto listings nightly from 500+ companies' own career pages (Getro networks, Ashby, Lever) — not pay-to-post
- Remote filters (region hubs for EMEA/APAC/Americas), normalized salary data
- Listings that go offline are automatically removed within hours, so no dead links
- Free, no signup; every Apply goes straight to the employer's own posting

Happy to adjust wording or placement if needed.