### PR TITLE
Add Jobs in JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Career Vault](https://careervault.io/) - Hundreds of remote jobs added each day from thousands of company career pages. Free and no signup required.
   1. [Findwork](https://findwork.dev/) Crawls multiple job boards and enriches job postings with Glassdoor (reviews) and Crunchbase (funding).
   1. [Google Jobs](https://www.google.com/search?q=remote&ibp=htl;jobs#fpstate=tldetail&htidocid=IO0hI7dpKTSlzSKoAAAAAA%3D%3D&htin=1&htivrt=jobs)  – Aggregates from multiple boards and employer sites with sensitivity to location, job type, and more. Find out how to use it [here](https://support.google.com/websearch/answer/7498276?p=job_search_box&sa=X&ved=0ahUKEwid_qyLmJfXAhVD4YMKHYGBAK8Qra4CCGQoAQ&visit_id=1-636449234996681631-3229288694&rd=1).
+  1. [Jobs in JavaScript](https://jobsinjs.com/remote-javascript-jobs/) - Remote JavaScript, TypeScript, Node.js roles from career pages. Refreshed daily.
   1. [JS Remotely](https://javascript.jobs/remote) - All remote JavaScript jobs on one board
   1. [Remote.io](https://www.remote.io/) - Job board and aggregator for remote jobs, primarily tech.
   1. [Remote 4 Me](https://remote4me.com/) - An aggregator for remote jobs in tech and non-tech.


### PR DESCRIPTION
Jobs in JavaScript is a niche, JavaScript-focused job board. Jobs are sourced directly from company career pages and refreshed daily. Includes filters for TypeScript, React, Node.js etc.

No paywall, no login required to browse.
