### PR TITLE
Add ParlayJobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [usdevjobs.com](https://usdevjobs.com/) - Real-time job aggregator for software, AI, data, engineers in US.
   1. [Vollna](https://www.vollna.com/) - An aggregator for top freelance sites.
   1. [whoishiring.io](https://whoishiring.io/#!/search/19.41/-43.14/2/?remote=true)
+  2. [ParlayJobs](https://www.parlayjobs.com/) - Specialist job board for iGaming and betting-tech careers, featuring verified remote jobs.
 
 ## Housing
   1. [bedndesk](https://www.bedndesk.com/) - Coworking & coliving space in Mallorca island in Spain


### PR DESCRIPTION
<!-- Thanks for adding a resource about remote work to this list! 🎉

Add the URL below -->

https://www.parlayjobs.com

<!-- And then, explain what this URL adds and why it is awesome -->

ParlayJobs is a specialist job board for the fast-growing sports prediction, iGaming, analytics and betting-tech industry. Unlike broad remote job boards, every role is sourced directly from a pre-approved employer, helping filter out fake, misleading or recycled remote listings. All the jobs list directly to an employer career or ATS page, no second hand jobs. The site has a dedicated remote jobs section covering opportunities across the industry. The industry is also global in nature, allowing for none-remote relocation opportunities. 

<!-- Make sure your pull request follows the [Contribution Guidelines](CONTRIBUTING.md) before submitting! Thank you. -->
