### PR TITLE
Add First Look Jobs to Job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Drupal Jobs](https://jobs.drupal.org/home/type/telecommute-remote-3588)
   1. [hiring.lat](https://hiring.lat) — Transparent job postings for LATAM workers with remote or relocation opportunities.
   1. [Findjobit](https://findjobit.com/jobs) - Remote jobs for LATAM IT professionals.
+  1. [First Look Jobs](https://firstlookjobs.com) - Remote AI training and domain-expert jobs from six referral programs, with advertised pay, weekly hours and country eligibility parsed from each listing.
   1. [FoundRole](https://foundrole.com/) - AI-powered job search platform and job application tracker for knowledge workers.
   1. [freelancermap](https://www.freelancermap.com/projects/remote.html) - Freelance & contract jobs for IT experts (mostly German projects)
   1. [Golangprojects](https://www.golangprojects.com/golang-remote-jobs.html) filter -> Remote only


### PR DESCRIPTION
Adds First Look Jobs to Job boards.

**What it is:** a directory of remote jobs from six programmes that hire people
to train and evaluate AI systems (Mercor, micro1, Turing, Alignerr, Contra,
Handshake AI). 741 open jobs at time of writing, re-scraped daily.

**Why it is different from the boards already listed:** it publishes what the
programmes themselves publish but no aggregator surfaces — advertised pay
range, weekly hours committed, and per-listing country eligibility. That last
one is the substantive difference: the site parses each programme's own
eligibility rules, so you can filter to jobs actually open to applicants in
your country rather than reading "Remote" and finding out after applying.
It also publishes original measurements over the whole catalogue at
/research, including that 47% of the listings which publish weekly hours ask
for less than full time.

**Rules checklist:**
- No paywall, no login, no signup. Every page is fully public.
- Links to the programme's own application, never a single job post.
- Alphabetically sorted, between Findjobit and FoundRole.
- Objective wording, no marketing language.

**Disclosure:** the site is monetised through the programmes' referral
schemes and earns a commission if a listed programme hires someone. This is
disclosed in the site footer on every page. Noting it explicitly here since
it is the site's business model — the same model as Gridnaut Recruiting,
already listed on line 163.
