### PR TITLE
Added HireRubyDevs resource (ruby niche job board with highest number of remote job postings on Internet)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Remotive Jobs](https://remotive.com/)
   1. [Remote Works](https://remote.works-hub.com) - Remote jobs in software development
   1. [Ruby On Remote](https://rubyonremote.com/) - All ruby remote jobs in one place
+  1. [HireRubyDevs](https://hirerubydevs.com/remote-ruby-on-rails-jobs) - One place for hundreds of ruby remote jobs anyday.
   1. [Skip the Drive](https://www.skipthedrive.com/)
   1. [Slasify](https://slasify.com/en) - Remote tech, art/design and marketing opportunities from Asia, global payroll service included.
   1. [Stream Native Jobs](https://streamnative.io/careers) - Scroll down to `Join Us`


### PR DESCRIPTION

This Updates README.md

Link:
https://hirerubydevs.com/remote-ruby-on-rails-jobs

Why it should be added?
This platforms list highest number of ruby + rails postings in the world with a option to see remote only jobs. At the time, I'm creating this PR, the platforms lists 785 remote ruby on rails jobs. It also updates in every 6 hours removing any stale postings & brings all the fresh jobs for ruby community.
