### PR TITLE
Add WeWorkFromHome

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [UN Talent](https://untalent.org/jobs/home-based) - Vacancies at the United Nations and its agencies.
   1. [usdevjobs.com](https://usdevjobs.com/) - Real-time job aggregator for software, AI, data, engineers in US.
   1. [Vollna](https://www.vollna.com/) - An aggregator for top freelance sites.
+  1. [WeWorkFromHome](https://weworkfromhome.com) - Aggregates remote jobs daily from Greenhouse, Lever, and Ashby company boards.
   1. [whoishiring.io](https://whoishiring.io/#!/search/19.41/-43.14/2/?remote=true)
 
 ## Housing


### PR DESCRIPTION
Adds [WeWorkFromHome](https://weworkfromhome.com) to Job boards aggregators.

Why it's different: rather than scraping generic job feeds, it pulls listings directly from companies' own Greenhouse, Lever, and Ashby career-page APIs, so every listing links back to the company's real posting. No login, no paywall, free for job seekers.