### PR TITLE
Add Toolkit Labs Invoice to Law & Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Your Tax Base](https://yourtaxbase.com/) - Florida residency and tax domicile services for digital nomads and remote workers, with virtual mailbox, Declaration of Domicile filing, and step-by-step guidance for establishing a tax-free home base.
   1. [Transferwise](https://wise.com/gb/business/payouts) - Easy way to pay remote employees.
   1. [VerdeDesk](https://verdedesk.vercel.app/) - Issue Portuguese green receipts (recibos verdes) and manage freelancer tax compliance in Portugal — in plain English. Built for D8 visa holders and expat freelancers.
+  1. [Toolkit Labs Invoice](https://ytinumoc.github.io/toolkitlabs-invoice/) - Free browser invoice/receipt PDF generator for remote freelancers (no account). [Commercial license (EUR 249)](https://buy.stripe.com/bJeeVea187TScZwb095Ne0k?client_reference_id=awesome-remote-job-v1) includes white-label PDF, 6 templates, and unlimited batch CLI.
 
 ## Others
   1. [awesome-digital-nomads](https://github.com/cbovis/awesome-digital-nomads) - 🏝 A curated list of awesome resources for Digital Nomads.


### PR DESCRIPTION
Adds [Toolkit Labs Invoice](https://ytinumoc.github.io/toolkitlabs-invoice/) under Law & Finance for remote freelancers.

- Free browser invoice/receipt PDF generator (no account)
- Commercial license (EUR 249): white-label, 6 templates, unlimited batch CLI
- One-time purchase alternative to subscription invoicing tools

Demo: https://ytinumoc.github.io/toolkitlabs-invoice/

Made with [Cursor](https://cursor.com)