### PR TITLE
Add iScribby into the tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,6 +606,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Timing](https://timingapp.com/?lang=en) - Automatic time and productivity tracking for Mac. Helps you stay on track with your work (especially important when working remotely). Also ensures that no billable hours get lost if you are billing hourly (Mac).
   1. [SYNCDATE](https://syncdate.app) - Automatically syncs events across multiple Google Calendar accounts — great for remote workers juggling work and personal schedules.
   1. [FastTool](https://fasttool.app) - 800+ browser-based productivity utilities (JSON formatter, regex tester, color tools, time zone converter, meeting cost calculator). No signup, works offline after first visit — handy when working across different networks.
+  1. [iScribby](https://iscribby.com/) - A neat little tool that allows you to draw directly on your screen, from anywhere - be it during a call while sharing your screen or over a presentation of any kind.
 
 ## Law & Finance
   1. [1099 contractors](https://www.smartcapitalmind.com/what-is-a-1099-contractor.htm) – US based companies can hire remote workers as.


### PR DESCRIPTION
A proposal to add iScribby into the Tools list.

**Website:**
https://iscribby.com/

**Benefit of the addition:**
It's a desktop application that allows you to draw directly on to your screen over anything (full-screen apps as well), while being as unobtrusive as possible. This can be useful for any sort of collaborative work, where you need to share your screen and you want to highlight something or note something down right on the screen, as you are explaining something.
