### PR TITLE
Add Remote Impact

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [JS Remotely](https://javascript.jobs/remote) - All remote JavaScript jobs on one board
   1. [Remote.io](https://www.remote.io/) - Job board and aggregator for remote jobs, primarily tech.
   1. [Remote 4 Me](https://remote4me.com/) - An aggregator for remote jobs in tech and non-tech.
+  1. [Remote Impact](https://remoteimpact.org/) - Remote social-impact job aggregator with AI matching and alerts.
   1. [Remote Index](https://remoteindex.co/) - Job board and aggregator for remote jobs in tech.
   1. [Remote OK](https://remoteok.com/) - Scrapes many job board feeds for remote positions.
   1. [Remote Python](https://www.remotepython.com/) - Job board and aggregator specifically for remote Python jobs.


### PR DESCRIPTION
Remote Impact is a free remote-job aggregator focused on social-impact work, including climate, nonprofits, global health, AI safety, and related sectors. It is materially different from general remote boards in this list because it adds sector-focused discovery plus AI matching and job alerts.

The public site is browseable without a paywall or login: https://remoteimpact.org/