### PR TITLE
Add Autorec to Communication tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Remoteteam.com](https://gusto.com) – Automated payrolls, time off, HR tools, and compliance for remote companies.
 
 #### Communication
+  1. [Autorec](https://autorec.app) – Desktop app that detects Zoom, Teams and Google Meet calls, records them locally and transcribes them on your own machine.
   1. [Codeshare.io](https://codeshare.io/) – Browser-based multi-user live code sharing with optional video chat.
   1. [Fleep](https://fleep.io/) - Internal chat and collaboration tool for development teams
   1. [Floobits](https://floobits.com) - Remote pair programming with screen share. Integrates with Sublime, IntelliJ, Atom and others


### PR DESCRIPTION
[Autorec](https://autorec.app) is a desktop app for people whose work happens in calls: it notices when a Zoom, Microsoft Teams or Google Meet window opens, records the meeting to an MP4 on the local disk, and transcribes it afterwards on the same machine with whisper.cpp. No bot joins the call, so nothing shows up in the participant list, and no audio is uploaded — which is the part that matters for contractors and consultants working under NDA.

Linux, Windows and macOS. Added alphabetically under `#### Communication`.