### PR TITLE
Add RoleSense

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1. [Remote Index](https://remoteindex.co/) - Job board and aggregator for remote jobs in tech.
   1. [Remote OK](https://remoteok.com/) - Scrapes many job board feeds for remote positions.
   1. [Remote Python](https://www.remotepython.com/) - Job board and aggregator specifically for remote Python jobs.
+  1. [RoleSense](https://role-sense.com/) - Remote jobs from career pages. Shows allowed countries per role. No signup to browse.
   1. [SlashJobs](https://slashjobs.com/) - Remote dev jobs aggregator. `and`/`or`/`not` filters, location search, fast, no sign-up/login.
   1. [tokenjobs.io](https://tokenjobs.io?remote=true) A web3 job aggregator where jobs can be filtered based on keywords, locations, languages and contract types. Anyone can publish a job offer.
   1. [UN Talent](https://untalent.org/jobs/home-based) - Vacancies at the United Nations and its agencies.


### PR DESCRIPTION
**What this adds**

One entry under `Job boards aggregators` for RoleSense, placed alphabetically between Remote Python and SlashJobs.

**Why it's different from what's already listed**

Per guideline 1, what this does that existing entries don't:

1. **Per-role location eligibility shown up front.** Every listing shows which countries the role is actually open to. Across 14,679 fully-remote ads on the board, 98.8% restrict where you can live — usually to a single country. No other board on this list surfaces that per role, so elsewhere you have to open each posting to find the fence.
2. **Work-style signals extracted from the posting text, and filterable.** Autonomy, pace, flexible hours, meeting load and process structure are parsed per job, so two roles with the same title can be distinguished before applying. The nearest existing entries (JobsByCulture, Diversify Tech) use company-level ratings or self-reported data rather than per-posting extraction.
3. **Sourced from company ATS boards directly** — Greenhouse, Lever, Ashby, Workable, Recruitee, Breezy and others — rather than reposted or employer-submitted listings.

**Access, stated plainly**

Browsing and filtering by skill and country needs no account. Saved searches and match alerts need a free account; the per-job application tooling is paid. Flagging this explicitly given guideline 1 — happy to reword or withdraw if that's disqualifying. (Daily Remote's existing entry states "Requires premium membership to view and apply," so I've assumed stating it is the expectation rather than a bar.)

**Checklist**

- [x] Link works, points to the right location
- [x] Appropriate section, alphabetical placement
- [x] Individual PR for a single suggestion
- [x] Name + description under 100 characters (97)
- [x] Objective wording, no marketing language
- [x] Live with content since February 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)
